### PR TITLE
added isPrimary key and few other values to minified

### DIFF
--- a/synapseAnnotations/data/common/minimal_Sage_standard.json
+++ b/synapseAnnotations/data/common/minimal_Sage_standard.json
@@ -148,7 +148,7 @@
         "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3328787/"
       },
       {
-        "value": "MudPIT-massSpec", 
+        "value": "MudPIT", 
         "description": "MudPIT is a method for rapid and large-scale protein identification by multidimensional liquid chromatography associated with tandem mass spectrometry", 
         "source": "http://purl.obolibrary.org/obo/MI_0658"
       }

--- a/synapseAnnotations/data/common/minimal_Sage_standard.json
+++ b/synapseAnnotations/data/common/minimal_Sage_standard.json
@@ -964,6 +964,11 @@
         "value": "SequenomMultiplex",
         "description": "",
         "source": ""
+      },
+      {
+        "value": "HiSeqX",
+        "description": "A whole-genome sequencing platform",
+        "source": ""
       }
     ]
   },

--- a/synapseAnnotations/data/common/minimal_Sage_standard.json
+++ b/synapseAnnotations/data/common/minimal_Sage_standard.json
@@ -146,6 +146,11 @@
         "value": "MIB/MS", 
         "description": "Kinomics assay using multiplexed kinase inhibitor beads and mass spectrometry (MIB/MS)", 
         "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3328787/"
+      },
+      {
+        "value": "MudPIT-massSpec", 
+        "description": "MudPIT is a method for rapid and large-scale protein identification by multidimensional liquid chromatography associated with tandem mass spectrometry", 
+        "source": "http://purl.obolibrary.org/obo/MI_0658"
       }
     ]
   },
@@ -598,11 +603,6 @@
         "source": "https://www.nih.gov/news-events/news-releases/decoding-molecular-ties-between-vascular-disease-alzheimers"
       }, 
       {
-        "value": "Synodos", 
-        "description": "", 
-        "source": "http://www.ctf.org/research/synodos"
-      }, 
-      {
         "value": "BSMN", 
         "description": "Brain Somatic Mosaicism Network", 
         "source": "https://www.synapse.org/#!Synapse:syn7344947/wiki/407304"
@@ -826,6 +826,11 @@
         "value": "flagstat",
         "description": "Output of samtools flagstat tool",
         "source": ""
+      },
+      {
+        "value": "gtf",
+        "description": "Gene transfer format (GTF) is a file format used to hold information about gene structure",
+        "source": "https://en.wikipedia.org/wiki/Gene_transfer_format"
       }
     ]
   },
@@ -972,6 +977,24 @@
         "value": true,
         "description": "",
         "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "isPrimaryCell", 
+    "description": "Boolean flag indicating whether or not cellType is primary", 
+    "columnType": "BOOLEAN", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": true,
+        "description": "A cell taken directly from a living organism, which is not immortalized",
+        "source": "http://purl.obolibrary.org/obo/BTO_0001413"
       },
       {
         "value": false,

--- a/synapseAnnotations/data/common/minimal_Sage_standard.json
+++ b/synapseAnnotations/data/common/minimal_Sage_standard.json
@@ -831,6 +831,16 @@
         "value": "gtf",
         "description": "Gene transfer format (GTF) is a file format used to hold information about gene structure",
         "source": "https://en.wikipedia.org/wiki/Gene_transfer_format"
+      },
+      {
+        "value": "raw",
+        "description": "Proprietary file format for mass spectrometry data from Thermo Scientific",
+        "source": "http://edamontology.org/format_3712"
+      },
+      {
+        "value": "msf",
+        "description": "Proprietary mass-spectrometry format of Thermo Scientific's ProteomeDiscoverer software",
+        "source": "http://edamontology.org/format_3702"
       }
     ]
   },


### PR DESCRIPTION
This is to clear up the issue of having primary cells in cellTypes. There are four cells I added in my last pull request that are primary or the not primary equivalent (arachnoid, primary arachnoid, meningioma, primary meningioma). 
@teslajoy removed the primary arachnoid and primary meningioma for me, and I'm adding an isPrimary boolean to make it easy to flag these cell lines (allowing me to just annotate these lines as arachnoid or meningioma, with isPrimary True or False).

I also added a couple other changes that I mentioned in issues in the past week. 