### PR TITLE
Added ability for RESTful API

### DIFF
--- a/synapseAnnotations/data/tool_annotations.json
+++ b/synapseAnnotations/data/tool_annotations.json
@@ -73,6 +73,11 @@
         "value": "Shell",
         "description": "",
         "source": ""
+      },
+      {
+        "value": "REST",
+        "description": "",
+        "source": ""
       }
     ]
   },
@@ -169,6 +174,11 @@
       }, 
       {
         "value": "containerToolRegistry",
+        "description": "",
+        "source": ""
+      }, 
+      {
+        "value": "API",
         "description": "",
         "source": ""
       }


### PR DESCRIPTION
Some people want their RESTful API to be linked on Synapse. This change reflects the annotations.