### PR TITLE
Update sageCommunity.json

### DIFF
--- a/synapseAnnotations/data/sageCommunity.json
+++ b/synapseAnnotations/data/sageCommunity.json
@@ -334,7 +334,23 @@
         "value": "rmd",
         "description": "markdown document specific to r analyses",
         "source": "http://rmarkdown.rstudio.com/developer_document_templates.html"
+      },
+      {
+        "value": "bed narrowPeak",
+        "description": "This format is used to provide called peaks of signal enrichment based on pooled, normalized (interpreted) data. It is a BED6+4 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format12"
+      },
+      {
+        "value": "bed broadPeak",
+        "description": "This format is used to provide called regions of signal enrichment based on pooled, normalized (interpreted) data. It is a BED 6+3 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format13"
+      },
+      {
+        "value": "bed gappedPeak",
+        "description": "This format is used to provide called regions of signal enrichment based on pooled, normalized (interpreted) data where the regions may be spliced or incorporate gaps in the genomic sequence. It is a BED12+3 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format14"
       }
+
     ]
   }
 ]


### PR DESCRIPTION
added ENCODE formats for bed files, using 'bed' prefix as they do in their data matrix explorer.