### PR TITLE
renamed key "nf1/nf2genotype"

### DIFF
--- a/synapseAnnotations/data/neurofibromatosis.json
+++ b/synapseAnnotations/data/neurofibromatosis.json
@@ -41,22 +41,22 @@
       {
         "value": "-/-", 
         "description": "Homozygous deletion, mutation or other form of NF2 deficiency (eg shRNA knockdown of NF2)", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }, 
       {
         "value": "+/-", 
         "description": "Heterozygous deletion or mutation", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }, 
       {
         "value": "+/+", 
         "description": "Homozygous wild type", 
-        "source": ""
+        "source": "Sage Bionetworks"
       },
       {
         "value": "unknown", 
         "description": "", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }
     ]
   }, 
@@ -69,22 +69,22 @@
       {
         "value": "-/-", 
         "description": "Homozygous deletion, mutation, or other form of NF1 deficiency (eg shRNA knockdown of NF1)", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }, 
       {
         "value": "+/-", 
         "description": "Heterozygous deletion or mutation", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }, 
       {
         "value": "+/+", 
         "description": "Homozygous wildtype", 
-        "source": ""
+        "source": "Sage Bionetworks"
       },
       {
         "value": "unknown", 
         "description": "", 
-        "source": ""
+        "source": "Sage Bionetworks"
       }
     ]
   }

--- a/synapseAnnotations/data/neurofibromatosis.json
+++ b/synapseAnnotations/data/neurofibromatosis.json
@@ -33,14 +33,14 @@
     ]
   }, 
   {
-    "name": "nf2Genotype", 
+    "name": "nf2Status", 
     "description": "Genotype of NF2 gene, if known", 
     "columnType": "STRING", 
     "maximumSize": 250, 
     "enumValues": [
       {
         "value": "-/-", 
-        "description": "Homozygous deletion or mutation", 
+        "description": "Homozygous deletion, mutation or other form of NF2 deficiency (eg shRNA knockdown of NF2)", 
         "source": ""
       }, 
       {
@@ -61,14 +61,14 @@
     ]
   }, 
   {
-    "name": "nf1Genotype", 
+    "name": "nf1Status", 
     "description": "Genotype of NF1 gene, if known", 
     "columnType": "STRING", 
     "maximumSize": 250, 
     "enumValues": [
       {
         "value": "-/-", 
-        "description": "Homozygous deletion or mutation", 
+        "description": "Homozygous deletion, mutation, or other form of NF1 deficiency (eg shRNA knockdown of NF1)", 
         "source": ""
       }, 
       {


### PR DESCRIPTION
"genotype" doesn't capture all of the genetic perturbations in the NF1/NF2 datasets. for example, HS01 cells have constitutively expressed shRNA targeting NF2 that results in extreme NF2 deficiency, but it is still NF2 +/+ 

renaming the key expands it's utility. could explore changing "-/-" to "deficient"in the scenario illustrated above.