### PR TITLE
add compoundDoseRange

### DIFF
--- a/synapseAnnotations/data/compoundScreen.json
+++ b/synapseAnnotations/data/compoundScreen.json
@@ -518,5 +518,12 @@
         "columnType":"STRING",
         "maximumSize": 250,
         "enumValues": []
-    }
+    },
+    {
+      "name": "compoundDoseRange",
+      "description": "The minimum and maximum values of a treatment range; e.g. 1-25",
+      "columnType": "STRING",
+      "maximumSize": 250,
+      "enumValues": []
+  },
   ]

--- a/synapseAnnotations/data/compoundScreen.json
+++ b/synapseAnnotations/data/compoundScreen.json
@@ -525,5 +525,5 @@
       "columnType": "STRING",
       "maximumSize": 250,
       "enumValues": []
-  },
+  }
   ]


### PR DESCRIPTION
Adding compoundDoseRange, a string that represents the min-max values of a drug/compound/antibody treatment range.