### PR TITLE
Added missing dictionary items to key

### DIFF
--- a/synapseAnnotations/data/neuro.json
+++ b/synapseAnnotations/data/neuro.json
@@ -7,9 +7,11 @@
     "enumValues": []
   }, 
   {
-     "name": "isConsortiumAnalysis", 
-     "description": "Collaborative consortium analysis", 
-     "columnType": "BOOLEAN"
+    "name": "isConsortiumAnalysis",
+    "description": "Collaborative consortium analysis",
+    "columnType": "BOOLEAN",
+    "maximumSize": 250,
+    "enumValues": []
   }, 
   {
     "name": "group", 


### PR DESCRIPTION
Key has been skipped from neuro module in annotations table v8.0.0 due to missing maxSize and enumVal list items.