### PR TITLE
Added value VZ/SVZ to tissue key

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -644,6 +644,11 @@
         "value": "middle frontal gyrus",
         "description": "Component of the frontal lobe, lateral aspect",
         "source": "http://purl.obolibrary.org/obo/UBERON_0002702"
+      },
+      {
+        "value": "VZ/SVZ",
+        "description": "VZ/SVZ (ventricular zone/subventricular zone) are proliferative transient zones situated near the surface of the cerebral lateral ventricles",
+        "source": "Sage Bionetworks"
       }
     ]
   },


### PR DESCRIPTION
A collaborator has samples where they didn't separate two brain tissues and would like to indicate them both in the annotations:

"We didn’t separate VZ and SVZ in the brain dissection so would prefer using VZ/SVZ as the term. The description will be 'VZ/SVZ are proliferative transient zones situated near the surface of the cerebral lateral ventricles'."

The definitions separately for the two regions are:
**ventricular zone**: Proliferative region that is part of the ventricular system
**subventricular zone**: The subventricular zone (SVZ) is a paired brain structure situated throughout the lateral walls of the lateral ventricles. Along with the subgranular zone of dentate gyrus, subventricular zone serves as a source of neural stem cells in the process of adult neurogenesis. It harbors the largest population of proliferating cells in the adult brain of rodents, monkeys and humans.