### PR TITLE
Add existing annotations to ontologies folder

### DIFF
--- a/synapseAnnotations/json_schema/ontology/analysis.json
+++ b/synapseAnnotations/json_schema/ontology/analysis.json
@@ -1,0 +1,617 @@
+[
+  {
+    "name": "assemblyMethod",
+    "description": "Algorithm used to build a reference genome from short read sequencing data.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Velvet",
+        "description": "Velvet: An algorithm for de novo short read assembly using de Bruijn graphs",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2336801/"
+      }
+    ]
+  },
+  {
+    "name": "batchEffectCorrectionMethod",
+    "description": "Methods for identifying or correcting potential confounding variables in regression analyses.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "COMBAT",
+        "description": "An empirical Bayes gene expression batch correction method with known covariates",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/16632515"
+      },
+      {
+        "value": "surrogate variable analysis",
+        "description": "Surrogate Variable Analysis: identification and adjustment for hidden confounds that are independent of a known outcome",
+        "source": "http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.0030161"
+      },
+      {
+        "value": "Principal Component Analysis",
+        "description": "Principal Component Analysis: Mathematical procedure that transforms a number of possibly correlated variables into a smaller number of uncorrelated variables called principal components.",
+        "source": "http://purl.bioontology.org/ontology/MESH/D025341"
+      }
+    ]
+  },
+  {
+    "name": "clusteringMethod",
+    "description": "A method to identify groups of similar variables based on their data distribution.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "hierarchical clustering",
+        "description": "A hierarchical clustering is a data transformation which achieves a class discovery objective, which takes as input data item and builds a hierarchy of clusters. The traditional representation of this hierarchy is a tree (visualized by a dendrogram), with the individual input objects at one end (leaves) and a single cluster containing every object at the other (root).",
+        "source": "http://purl.obolibrary.org/obo/OBI_0200042"
+      },
+      {
+        "value": "k-means clustering",
+        "description": "A k-means clustering is a data transformation which achieves a class discovery or partitioning objective, which takes as input a collection of objects (represented as points in multidimensional space) and which partitions them into a specified number k of clusters. The algorithm attempts to find the centers of natural clusters in the data. The most common form of the algorithm starts by partitioning the input points into k initial sets, either at random or using some heuristic data. It then calculates the mean point, or centroid, of each set. It constructs a new partition by associating each point with the closest centroid. Then the centroids are recalculated for the new clusters, and the algorithm repeated by alternate applications of these two steps until convergence, which is obtained when the points no longer switch clusters (or alternatively centroids are no longer changed).",
+        "source": "http://purl.obolibrary.org/obo/OBI_0200041"
+      },
+      {
+        "value": "Weighted correlation network analysis",
+        "description": "A data mining method typically used for studying biological networks based on pairwise correlations between variables.",
+        "source": "http://edamontology.org/operation_3766"
+      },
+      {
+        "value": "principal component analysis",
+        "description": "Principal Component Analysis: Mathematical procedure that transforms a number of possibly correlated variables into a smaller number of uncorrelated variables called principal components.",
+        "source": "http://purl.bioontology.org/ontology/MESH/D025341"
+      }
+    ]
+  },
+  {
+    "name": "somaticMutationCallingMethod",
+    "description": "Algorithm to call somatic mutations.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "VarDict",
+        "description": "A DNA and RNA seq variant caller in cancer research.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/27060149"
+      },
+      {
+        "value": "MuTect",
+        "description": "A method to detect DNA point mutations in heterogeneous and impure cancer samples.",
+        "source": "https://www.nature.com/articles/nbt.2514"
+      },
+      {
+        "value": "VarScan",
+        "description": "A method to detect variants from short read DNA sequencing in individual and pooled samples.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/19542151"
+      }
+    ]
+  },
+  {
+    "name": "multipleTestingAdjustmentMethod",
+    "description": "Method used to control either family wise error rate, false discovery rate, or other measures of burden of false positives and false negatives when performing multiple statistical tests.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Benjamini Hochberg",
+        "description": "A sequential p-value procedure that controls expected false discovery rate.",
+        "source": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C61596"
+      },
+      {
+        "value": "Bonferroni",
+        "description": "Used in multiple comparison procedures to calculate an adjusted probability, alpha (a), of comparison-wise type I error from the desired probability aFW0 of family-wise type I error. The calculation guarantees that the use of the adjusted a in pairwise comparisons keeps the actual probability aFW of family-wise type I errors not higher than the desired level, as specified by aFW0.",
+        "source": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C61594"
+      }
+    ]
+  },
+  {
+    "name": "peakCallingMethod",
+    "description": "The algorithm used to identify protein-binding regions in a genome sequence from the data generated from a ChIP-sequencing or ChIP-chip experiment.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "MACS",
+        "description": "A dynamic Poisson process based method to identify ChIP-Seq peaks.",
+        "source": "https://genomebiology.biomedcentral.com/articles/10.1186/gb-2008-9-9-r137"
+      },
+      {
+        "value": "GEM",
+        "description": "EM algorithm to identify ChIP-Seq peaks and enriched motifs.",
+        "source": "http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1002638"
+      }
+    ]
+  },
+  {
+    "name": "transcriptQuantificationMethod",
+    "description": "Method for quantifying abundance of transcript expression.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "kallisto",
+        "description": "Alignment free quantification method for transcripts.",
+        "source": "https://www.nature.com/articles/nbt.3519"
+      },
+      {
+        "value": "RSEM",
+        "description": "Transcript qunatification without a reference genome.",
+        "source": "https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-12-323"
+      },
+      {
+        "value": "featureCounts",
+        "description": "A method for assigning sequence reads to genomic features.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/24227677"
+      },
+      {
+        "value": "bedtools multicov",
+        "description": "Reports the count of alignments from multiple position-sorted and indexed BAM files that overlap intervals in a BED file.",
+        "source": "http://bedtools.readthedocs.io/en/latest/content/tools/multicov.html"
+      }
+    ]
+  },
+  {
+    "name": "statisticalNetworkReconstructionMethod",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Weighted correlation network analysis",
+        "description": "A data mining method typically used for studying biological networks based on pairwise correlations between variables.",
+        "source": "http://edamontology.org/operation_3766"
+      },
+      {
+        "value": "SPARROW",
+        "description": "Sparse conditional independence graph construction from gene expression data using a variational Bayes spike regression neighorhood selection method.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/?term=25583238"
+      },
+      {
+        "value": "Lasso",
+        "description": "Sparse conditional independence graph construction from gene expression data using an L1 penalized regression neighborhood selection method.",
+        "source": "https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-10-384"
+      },
+      {
+        "value": "ridge",
+        "description": "Conditional independence graph construction from gene expression using an L2^2 penalized regression neighborhood selection method.",
+        "source": "https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-10-384"
+      },
+      {
+        "value": "GENIE3",
+        "description": "Gene expression network reconstruction using random forests.",
+        "source": "http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0012776"
+      },
+      {
+        "value": "TIGRESS",
+        "description": "Gene expression network reconstruction using stability selection.",
+        "source": "https://bmcsystbiol.biomedcentral.com/articles/10.1186/1752-0509-6-145"
+      },
+      {
+        "value": "ARACNE",
+        "description": "Gene expression network reconstruction using mutual information.",
+        "source": "https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-7-S1-S7"
+      },
+      {
+        "value": "MRNET",
+        "description": "An information theoretic method to infer gene expression networks.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/18354736"
+      },
+      {
+        "value": "C3NET",
+        "description": "Method to infer causal relationships in gene expression networks with mutual information.",
+        "source": "https://bmcsystbiol.biomedcentral.com/articles/10.1186/1752-0509-4-132"
+      },
+      {
+        "value": "MEGENA",
+        "description": "Multiscale Embedded Gene Co-expression Network Analysis",
+        "source": "http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004574"
+      },
+      {
+        "value": "WINA",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "differentialExpressionMethod",
+    "description": "Method used to test for differentially expressed genes or isoforms.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "limma",
+        "description": "Data analysis, linear models and differential expression for microarray data.",
+        "source": "http://www.ebi.ac.uk/efo/swo/SWO_0000593"
+      },
+      {
+        "value": "sleuth",
+        "description": "Differential expression analysis incorporating quantification uncertainty.",
+        "source": "https://www.nature.com/articles/nmeth.4324"
+      },
+      {
+        "value": "Cuffdiff 2",
+        "description": "Differential expression analysis of transcripts.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3869392/"
+      },
+      {
+        "value": "edgeR",
+        "description": "Estimation and Testing for Differential Expression in Multiple Digital Gene Expression Libraries.",
+        "source": "http://www.ebi.ac.uk/efo/swo/SWO_0000527"
+      }
+    ]
+  },
+  {
+    "name": "alignmentMethod",
+    "description": "DNA or RNA sequence alignment method",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Burrows-Wheeler technique",
+        "description": "Burrows Wheeler Alignment algorithm.",
+        "source": "http://purl.obolibrary.org/obo/ERO_0100332"
+      },
+      {
+        "value": "Bowtie",
+        "description": "A memory efficient short read alignment algorithm.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/19261174"
+      },
+      {
+        "value": "Bowtie 2",
+        "description": "A memory efficient short read alignment algorithm.",
+        "source": "https://www.nature.com/articles/nmeth.1923"
+      },
+      {
+        "value": "SNAPR",
+        "description": "A pipeline for short read alignment and downstream analyses.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/29270443"
+      },
+      {
+        "value": "GSNAP",
+        "description": "Method to detect complex variants and splicing in short read sequencing.",
+        "source": "https://academic.oup.com/bioinformatics/article/26/7/873/212606"
+      },
+      {
+        "value": "TopHat",
+        "description": "Method to align short read sequencing for outputs such as splice junction detection.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2672628/"
+      },
+      {
+        "value": "MOSAIC",
+        "description": "Segmentation alignment method for DNA alignment.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/11238079"
+      },
+      {
+        "value": "NovoAlign",
+        "description": "Short read sequencing alignment method.",
+        "source": "http://www.novocraft.com/products/novoalign/"
+      },
+      {
+        "value": "OLego",
+        "description": "Alignment method to detect de novo mapping of spliced mRNA-Seq reads.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/23571760"
+      },
+      {
+        "value": "STAR",
+        "description": "Software based on a previously undescribed RNA-seq alignment algorithm that uses sequential maximum mappable seed search in uncompressed suffix arrays followed by seed clustering and stitching procedure.",
+        "source": "https://academic.oup.com/bioinformatics/article/29/1/15/272537"
+      }
+    ]
+  },
+  {
+    "name": "validationMethod",
+    "description": "Method to test targeted sequence level hypothesis.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "CRISPR-Cas9",
+        "description": "Genome manipulation technique to incorporate or delete arbitrary sequence features into germline cells.",
+        "source": "http://science.sciencemag.org/content/346/6213/1258096.full"
+      },
+      {
+        "value": "RNAi",
+        "description": "The process in which double-stranded RNAs silence cognate genes. Involves posttranscriptional gene inactivation ('silencing') both of transgenes or dsRNA introduced into a germline, and of the host gene(s) homologous to the transgenes or dsRNA. This silencing is triggered by the introduction of transgenes or double-stranded RNA (dsRNA), and can occur through a specific decrease in the level of mRNA, or by negative regulation of translation, of both host genes and transgenes.",
+        "source": "http://purl.obolibrary.org/obo/GO_0016246"
+      },
+      {
+        "value": "shRNA",
+        "description": "Short hairpin RNA (shRNA) can be used to achieve stable knockdown of gene expression. shRNA molecules are cloned into lentiviral or other vectors and expressed by a pol III type promoter.",
+        "source": "http://www.bioassayontology.org/bao#BAO_0000323"
+      }
+    ]
+  },
+  {
+    "name": "enrichmentMethod",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Fisher's exact test",
+        "description": "Fisher's exact test is a data transformation used to determine if there are nonrandom associations between two Fisher's exact test is a statistical significance test used in the analysis of contingency tables where sample sizes are small where the significance of the deviation from a null hypothesis can be calculated exactly, rather than relying on an approximation that becomes exact in the limit as the sample size grows to infinity, as with many statistical tests.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0200176"
+      },
+      {
+        "value": "DAVID",
+        "description": "All tools in the DAVID Bioinformatics Resources aim to provide functional interpretation of large lists of genes derived from genomic studies.",
+        "source": "https://david.ncifcrf.gov"
+      },
+      {
+        "value": "GSEA",
+        "description": "A method to identify pathway enrichment in a sample set of genes.",
+        "source": "http://www.pnas.org/content/102/43/15545"
+      }
+    ]
+  },
+  {
+    "name": "analysisType",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Variant calling",
+        "description": "Identify and map genomic alterations, including single nucleotide polymorphisms, short indels and structural variants, in a genome sequence.",
+        "source": "http://edamontology.org/operation_3227"
+      },
+      {
+        "value": "Sequence alignment",
+        "description": "Alignment of reads to a reference genome",
+        "source": "http://edamontology.org/operation_0292"
+      },
+      {
+        "value": "genotype imputation",
+        "description": "The statistical inference of unobserved genotypes.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/17572673"
+      },
+      {
+        "value": "DNA methylation imputation",
+        "description": "The statistical inference of unobserved DNA methylation marks.",
+        "source": "https://dx.doi.org/10.1534/genetics.115.185967"
+      },
+      {
+        "value": "Polygenic Risk Scores",
+        "description": "A sample level estimate of the genetic component of disease risk based on genome-wide association studies.",
+        "source": "http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1003348"
+      },
+      {
+        "value": "Enrichment analysis",
+        "description": "Over-representation analysis.",
+        "source": "http://edamontology.org/operation_3501"
+      },
+      {
+        "value": "statistical network reconstruction",
+        "description": "Learning network relationships between genes based on their coexpression patterns.",
+        "source": "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Signaling_Network_Reconstruction"
+      },
+      {
+        "value": "differential expression",
+        "description": "Genes or isoforms that are differentially expressed between two conditions.",
+        "source": "http://uri.neuinfo.org/nif/nifstd/nlx_qual_100810"
+      },
+      {
+        "value": "expression quantitative trait loci detection",
+        "description": "A stretch of DNA at a particular chromosomal location that is able to regulate the expression of a specific mRNA or protein.",
+        "source": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C113415"
+      },
+      {
+        "value": "outlier detection",
+        "description": "An observation in a data set that is numerically distant from the rest of the data.",
+        "source": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C79083"
+      },
+      {
+        "value": "covariate specification",
+        "description": "A variable specification that specifies a variable used in statistical analysis to correct, adjust, or modify the values of a dependent variable; an independent variable not manipulated by the investigator",
+        "source": "http://purl.obolibrary.org/obo/OBCS_0000040"
+      },
+      {
+        "value": "hidden confounder detection",
+        "description": "Identification of a hidden or latent variable that may be inflating the type I error rate due to mutual correlation between dependent and independent variable that are being tested.",
+        "source": "http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.0030161"
+      },
+      {
+        "value": "differential network anaysis",
+        "description": "Identification of changes in coexpression patterns between two conditions.",
+        "source": "http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1000616"
+      },
+      {
+        "value": "methylation quantitative trait loci detection",
+        "description": "A stretch of DNA at a particular chromosomal location that is able to regulate the methylation of DNA.",
+        "source": ""
+      },
+      {
+        "value": "network driver detection",
+        "description": "Identification of drivers of disease based on network analyses.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4194029/"
+      },
+      {
+        "value": "principal component analysis",
+        "description": "Principal Component Analysis: Mathematical procedure that transforms a number of possibly correlated variables into a smaller number of uncorrelated variables called principal components.",
+        "source": "http://purl.bioontology.org/ontology/MESH/D025341"
+      },
+      {
+        "value": "Genome-Wide Association",
+        "description": "An analysis comparing the allele frequencies of all available (or a whole GENOME representative set of) polymorphic markers in unrelated patients with a specific symptom or disease condition, and those of healthy controls to identify markers associated with a specific disease or condition.",
+        "source": "http://purl.bioontology.org/ontology/MESH/D055106"
+      },
+      {
+        "value": "Clustering",
+        "description": "Group together some data entities on the basis of similarities such that entities in the same group (cluster) are more similar to each other than to those in other groups (clusters).",
+        "source": "http://edamontology.org/operation_3432"
+      },
+      {
+        "value": "Supervised Machine Learning",
+        "description": "A machine learning paradigm used to make predictions about future instances based on a given set of labeled paired input-output training (sample) data.",
+        "source": "http://purl.bioontology.org/ontology/MESH/D000069553"
+      },
+      {
+        "value": "batch effect correction",
+        "description": "Adjustment of variable of interest for batch effects.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/16632515"
+      },
+      {
+        "value": "ANOVA",
+        "description": "ANOVA or analysis of variance is a data transformation in which a statistical test of whether the means of several groups are all equal.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0200201"
+      },
+      {
+        "value": "variancePartition",
+        "description": "Identification of percentage variance explained of a dependent variable by multiple classes of independent variables.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5123296/"
+      },
+      {
+        "value": "visualization",
+        "description": "Resource that provides access to tools for graphical, interactive, multimodal and multidimensional data and result visualization.",
+        "source": "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Visualization"
+      },
+      {
+        "value": "transcript quantification",
+        "description": "Quantification of the abundunce of specific gene expression transcript isoforms.",
+        "source": "https://www.nature.com/articles/nbt.3519"
+      },
+      {
+        "value": "somatic mutation calling",
+        "description": "Identification of de-novo mutations in somatic cells.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4803342/"
+      },
+      {
+        "value": "peak calling",
+        "description": "An inferential statistical data analysis to identify protein-binding regions in a genome sequence from the data generated from a ChIP-sequencing or ChIP-chip experiment. When the protein is a transcription factor, the region is a transcription factor binding site (TFBS).",
+        "source": "http://purl.obolibrary.org/obo/OBCS_0000167"
+      },
+      {
+        "value": "Copy number estimation",
+        "description": "Estimate the number of copies of loci of particular gene(s) in DNA sequences typically from gene-expression profiling technology based on microarray hybridisation-based experiments.",
+        "source": "http://edamontology.org/operation_3233"
+      },
+      {
+        "value": "Gene expression comparison",
+        "description": "Comparison of gene expression profiles.",
+        "source": "http://edamontology.org/operation_0315"
+      },
+      {
+        "value":"de-novo assembly",
+        "description": "Assembly of reference sequence from short read sequences without external reference genome build.",
+        "source": "http://purl.obolibrary.org/obo/GENEPIO_0001628"
+      },
+      {
+        "value":"correlation",
+        "description":"The degree to which two or more quantities or events are linearly associated, a statistical relation between two or more variables such that systematic changes in the value of one variable are accompanied by systematic changes in the others.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C48834"
+      },
+      {
+        "value":"network analysis",
+        "description":"A data transformation that takes as input data that describes biological networks in terms of the node (a.k.a. vertex) and edge graph elements and their characteristics and generates as output properties of the constituent nodes and edges, the sub-graphs, and the entire network.",
+        "source":"http://purl.obolibrary.org/obo/OBI_0200080"
+      },
+      {
+        "value":"purity",
+        "description":"A quantitative assessment of the homogeneity or uniformity of a mixture. Alternatively, purity refers to the degree of being free of contaminants or heterogeneous components",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C62352"
+      },
+      {
+        "value":"dose response study",
+        "description":"A study of the effect of dose changes on the efficacy of a drug in order to determine the dose-response relationship and optimal dose of a therapy.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C127803"
+      },
+      {
+        "value":"assessment",
+        "description":"The final result of a determination of the value, significance, or extent of.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C25217"
+      },
+      {
+        "value":"quality control",
+        "description":"A technique used to ensure a certain level of quality in a product or service.",
+        "source":"http://purl.obolibrary.org/obo/ERO_0001219"
+      },
+      {
+        "value":"comparison",
+        "description":"The examination of two or more people or things in order to detect similarities and differences.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C49156"
+      },
+      {
+        "value": "data normalization",
+        "description": "",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/swo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fswo%2Fobjective%2FSWO_7000015"
+      }
+    ]
+  },
+  {
+    "name": "visualisationMethod",
+    "description": "The format in which data is visually displayed.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "scatter plot",
+        "description": "A scatterplot is a graph which uses Cartesian coordinates to display values for two variables for a set of data. The data is displayed as a collection of points, each having the value of one variable determining the position on the horizontal axis and the value of the other variable determining the position on the vertical axis.",
+        "source": "http://purl.obolibrary.org/obo/IAO_0000184"
+      },
+      {
+        "value": "heatmap",
+        "description": "A graphical representation of data where the values taken by a variable in a two-dimensional map are represented as colors.",
+        "source": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C78549"
+      },
+      {
+        "value": "bar chart",
+        "description": "The bart chart is a graph resulting from plotting rectangular bars with lengths proportional to the values that they represent.",
+        "source": "http://purl.obolibrary.org/obo/STATO_0000166"
+      }
+    ]
+  },
+  {
+    "name": "supervisedLearningMethod",
+    "description": "An algorithm to fit a model to make predictions of future outcomes based past data.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "penalized regression",
+        "description": "A regression model with a parametric constraint on the allowable solution space.",
+        "source": "https://statweb.stanford.edu/~tibs/lasso/lasso.pdf"
+      },
+      {
+        "value": "random forest",
+        "description": "A method to build an ensemble of decisions trees for classification or regression models.",
+        "source": "http://ect.bell-labs.com/who/tkh/publications/papers/odt.pdf"
+      },
+      {
+        "value": "support vector machine",
+        "description": "A support vector machine is a data transformation with a class prediction objective based on the construction of a separating hyperplane that maximizes the margin between two data sets of vectors in n-dimensional space.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0000700"
+      },
+      {
+        "value": "deep learning",
+        "description": "Rebranded artificial neural networks.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/25462637"
+      },
+      {
+        "value": "boosting",
+        "description": "An ensemble meta algorithm to average over many predictions to reduce bias and variance in predictions.",
+        "source": "https://web.archive.org/web/20150119081741/http://oz.berkeley.edu/~breiman/arcall96.pdf"
+      },
+      {
+        "value": "bagging",
+        "description": "An ensemble method to stabilize predictions, improve accuracy, and reduce variance for regression or decision tree models.",
+        "source": "https://link.springer.com/article/10.1007%2FBF00058655"
+      },
+      {
+        "value": "naive Bayes",
+        "description": "A classification model that assumes independence of predictors and uses Bayes theorem predict outcomes.",
+        "source": "http://engr.case.edu/ray_soumya/mlrg/optimality_of_nb.pdf"
+      },
+      {
+        "value": "Gaussian process regression",
+        "description": "A non parametric kernel based supervised learning regression method.",
+        "source": "http://www.inference.org.uk/itprnn/book.pdf"
+      },
+      {
+        "value": "elastic net",
+        "description": "Elastic net is a shrinkage and selection regression method that linearly combines the L1 and L2 penalties of the lasso and ridge methods.",
+        "source": "http://purl.enanomapper.org/onto/ENM_8000083"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/array.json
+++ b/synapseAnnotations/json_schema/ontology/array.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "channel",
+    "description": "Fluorescent color labeling for an array",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Cy5",
+        "description": "Fluorescent dye used for the red channel on an array",
+        "source": "http://purl.obolibrary.org/obo/FBbi_00000450"
+      },
+      {
+        "value": "Cy3",
+        "description": "Fluorescent dye used for the green channel on an array",
+        "source": "http://purl.obolibrary.org/obo/FBbi_00000449"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/cancer.json
+++ b/synapseAnnotations/json_schema/ontology/cancer.json
@@ -1,0 +1,210 @@
+[
+  {
+    "name": "transplantationType",
+    "description": "Type of transplantation involved in the experiment, derived from MESH",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "allograft",
+        "description": "Tissues, cells, or organs transplanted between genetically different individuals of the same species",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/68064591"
+      },
+      {
+        "value": "xenograft",
+        "description": "Tissues, cells or organs transplanted between animals of different species",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/68064593"
+      },
+      {
+        "value": "autograft",
+        "description": "Transplant comprised of an individual's own tissue, transferred from one part of the body to another.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/68064592"
+      },
+      {
+        "value": "isograft",
+        "description": "Tissues, cells or organs transplanted between genetically identical individuals",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/68064596"
+      }
+    ]
+  },
+  {
+    "name": "genePerturbationType",
+    "description": "Specific way in which a single gene was perturbed in a sample",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "overexpression",
+        "description": "Gene overexpression refers to genetic techniques in which an organism or cell line is engineered to express increased levels of a gene.",
+        "source": "http://www.bioassayontology.org/bao#BAO_0002442"
+      },
+      {
+        "value": "knockdown",
+        "description": "Gene knockdown refers to techniques by which the expression of one or more of an organism's genes is reduced, either through genetic modification (a change in the DNA of one of the organism's chromosomes) or by treatment with a reagent such as a short DNA or RNA oligonucleotide with a sequence complementary to either an mRNA transcript or a gene.",
+        "source": "http://www.bioassayontology.org/bao#BAO_0002433"
+      },
+      {
+        "value": "knockout",
+        "description": "A gene knockout is a genetic technique in which an organism is engineered to carry genes that have been made inoperative (have been 'knocked out' of the organism).",
+        "source": "http://www.bioassayontology.org/bao#BAO_0002441"
+      }
+    ]
+  },
+  {
+    "name": "genePerturbationTechnology",
+    "description": "Technology used to perform gene perturbation",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "RNAi",
+        "description": "High throughput sample analysis of RNAi molecules for potential application in gene knockdown or gene silencing of target genes",
+        "source": "http://purl.obolibrary.org/obo/ERO_0001688"
+      },
+      {
+        "value": "CRISPR",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "CRE Recombinase",
+        "description": "CRE Recombinase catalyses site-specific recombination between two 34 base pair loxp sites and maintains the phage genome as a monomeric unit-copy plasmid in the lysogenic state.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C17285"
+      }
+    ]
+  },
+  {
+    "name": "timePointUnit",
+    "description": "For timed experiments this represents the unit of time measured",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "hours",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "days",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "transplantationDonorSpecies",
+    "description": "Species from which donor tissue originated",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Human",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Mouse",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "tumorType",
+    "description": "The type of cells that carcinoma arises from.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Neurofibroma Cutaneous",
+        "description": "An intraneural or extraneural neoplasm arising from nerve tissues and neural sheaths of skin.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000622"
+      },
+      {
+        "value": "Neurofibroma Subcutaneous",
+        "description": "An intraneural neoplasm arising from nerve tissues and neural sheaths laying under the skin.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000622"
+      },
+      {
+        "value": "Neurofibroma Plexiform",
+        "description": "Plexiform neurofibromas are larger, more extensive tumors that grow from nerves anywhere in the body.",
+        "source": "https://nfcenter.wustl.edu/what-is-nf/neurofibromatosis-type-1/nerve-tumors/"
+      },
+      {
+        "value": "Neurofibroma Atypical",
+        "description": "An intraneural or extraneural neoplasm arising from nerve tissues and neural sheaths that does not belong to a known subtype.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000622"
+      },
+      {
+        "value": "Malignant Peripheral Nerve Sheath Tumor",
+        "description": "The tumors usually develop along peripheral or cranial nerves and are a central feature of NEUROFIBROMATOSIS 1, where they may occur intracranially or involve spinal roots.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000622"
+      },
+      {
+        "value": "Adenocarcinoma",
+        "description": "A common cancer characterized by the presence of malignant glandular cells. Morphologically, adenocarcinomas are classified according to the growth pattern (e.g., papillary, alveolar) or according to the secreting product (e.g., mucinous, serous).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/mp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C2852"
+      },
+      {
+        "value": "Carcinoma",
+        "description": "A cell type cancer that has_material_basis_in abnormally proliferating cells derives_from epithelial cells.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_305"
+      },
+      {
+        "value": "Ductal Carcinoma",
+        "description": "Invasive ductal carcinoma (IDC), an infiltrating, malignant and abnormal proliferation of neoplastic cells in the breast tissue, or ductal carcinoma in situ (DCIS), a noninvasive, possibly malignant, neoplasm that is still confined to the milk ducts (lactiferous ducts), where breast cancer most often originates.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0004851"
+      },
+      {
+        "value": "Melanoma",
+        "description": "A malignant, usually aggressive tumor composed of atypical, neoplastic melanocytes.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/mp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C3224"
+      },
+      {
+        "value": "Optic Nerve Glioma",
+        "description": "Optic pathway glioma (OPG) is a benign tumor that develop along the optic nerve (chiasm, tracts, and radiations) characterized by impairment or loss of vision and may be accompanied by diencephalic symptoms such as reduced growth and alteration in sleeping patterns. OPG are often linked to neurofibromatosis type 1.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/ordo/terms?iri=http%3A%2F%2Fwww.orpha.net%2FORDO%2FOrphanet_2086"
+      },
+      {
+        "value": "Low Grade Glioma",
+        "description": "Low grade gliomas are brain tumors that come from two different types of brain cells known as astrocytes and oligodendrocytes.",
+        "source": "https://www.urmc.rochester.edu/neurosurgery/specialties/neurooncology/conditions/low-grade-glioma.aspx"
+      },
+      {
+        "value": "Diffuse Astrocytoma",
+        "description": "Also called Low-Grade or Astrocytoma Grade II is a subtype of glial tumor of the brain or spinal cord showing astrocytic differentiation.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000272"
+      },
+      {
+        "value": "Anaplastic Astrocytoma",
+        "description": "A diffusely infiltrating, WHO grade III astrocytoma with focal or dispersed anaplasia, and a marked proliferative potential. It may arise from a low-grade astrocytoma, but it can also be diagnosed at first biopsy, without indication of a less malignant precursor lesion. It has an intrinsic tendency for malignant progression to glioblastoma.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002499"
+      },
+      {
+        "value": "Glioblastoma",
+        "description": "Develop primarily through increasing anaplasia of well differentiated gliomas, mainly astrocytomas or oligodendrogliomas. Typically large and contain cells of different sizes with irrregular nuclei and atypical mitotic figures.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/mpath/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMPATH_564"
+      },
+      {
+        "value": "Schwannoma",
+        "description": "A neoplasm that arises from SCHWANN CELLS of the cranial, peripheral, and autonomic nerves. ",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000693"
+      },
+      {
+        "value": "Meningioma",
+        "description": "A generally slow growing tumor attached to the dura mater. It is composed of neoplastic meningothelial (arachnoidal) cells.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/mp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C3230"
+      },
+      {
+        "value": "Myeloma",
+        "description": "A bone marrow cancer that is formed of any one of the bone marrow cells belonging to the granulocytic (neutrophil, eosinophil, basophil), monocytic/macrophage, erythroid, megakaryocytic and mast cell lineages.",
+        "source": "http://purl.obolibrary.org/obo/DOID_0070004"
+      },
+      {
+        "value": "Not Applicable",
+        "description": "",
+        "source": ""
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/chem.json
+++ b/synapseAnnotations/json_schema/ontology/chem.json
@@ -1,0 +1,96 @@
+[
+  {
+    "name": "chemicalDataType", 
+    "description": "The type of chemical data in the dataset.", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "target", 
+        "description": "The role of a molecular entity (protein or nucleic acid) that is the presumed subject of an assay and whose activity is being regulated by an entity with a perturbagen role in that assay.", 
+        "source": "http://www.bioassayontology.org/bao#BAO_0003064"
+      },
+      {
+        "value": "chemical structure", 
+        "description": "A representation of the arrangement of atoms and bonds. ", 
+        "source": "http://purl.obolibrary.org/obo/NCIT_C103240"
+      },
+      {
+        "value": "chemical hashed fingerprint", 
+        "description": "The chemical hashed fingerprint of a molecule is bit string (a sequence of 0 and 1 digits) that contains information on the structure.", 
+        "source": "https://docs.chemaxon.com/display/docs/Chemical+Hashed+Fingerprint"
+      },
+      {
+        "value": "complex database", 
+        "description": "A database with several types of chemical data", 
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "chemical identifier", 
+        "description": "A chemical identifier is an identifier for a chemical entity", 
+        "source": "http://semanticscience.org/resource/SIO_000728"
+      }
+    ]
+  },
+  {
+    "name": "fingerprintType", 
+    "description": "The type of chemical fingerprint used.", 
+    "columnType": "STRING", 
+    "maximumSize": 50,
+    "enumValues": [
+      {
+        "value": "standard", 
+        "description": "Considers paths of a given length. These are hashed fingerprints, with a default length of 1024.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      },
+      {
+        "value": "extended", 
+        "description": "Similar to the standard type, but takes rings and atomic properties into account into account.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      },
+      {
+        "value": "maccs", 
+        "description": "The popular 166 bit MACCS keys described by MDL.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      },
+      {
+        "value": "pubchem", 
+        "description": "881 bit fingerprints defined by PubChem.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      },
+      {
+        "value": "kr", 
+        "description": "4860 bit fingerprint defined by Klekota and Roth.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      },
+      {
+        "value": "circular", 
+        "description": "An implementation of the ECFP6 fingerprint.", 
+        "source": "https://www.rdocumentation.org/packages/rcdk/versions/3.4.5/topics/get.fingerprint"
+      }
+    ]
+  },
+  {
+    "name": "structureFormat", 
+    "description": "The chemical structural representation used.", 
+    "columnType": "STRING", 
+    "maximumSize": 50,
+    "enumValues": [
+      {
+        "value": "SMILES", 
+        "description": "Specification for unambiguously describing the structure of a chemical compound using a short ASCII string.", 
+        "source": "http://purl.obolibrary.org/obo/MS_1000868"
+      },
+      {
+        "value": "InChI", 
+        "description": "A textual identifier for chemical substances designed to provide a standard and human-readable way to encode molecular information that also facilitates searches in printed and electronic data sources.", 
+        "source": "http://purl.obolibrary.org/obo/NCIT_C54683"
+      },
+      {
+        "value": "SDF",
+        "description": "SDF is one of a family of chemical-data file formats developed by MDL Information Systems; it is intended especially for structural information.",
+        "source": "http://edamontology.org/format_3814"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/compoundScreen.json
+++ b/synapseAnnotations/json_schema/ontology/compoundScreen.json
@@ -1,0 +1,696 @@
+[
+  {
+    "name": "compoundName",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "A-1210477",
+        "description": "An MCL-1 inhibitor.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/2015744"
+      },
+      {
+        "value": "ABBVIE1",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE2",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE3",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE4",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE5",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE6",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE7",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE8",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "Venetoclax",
+        "description": "An orally bioavailable, selective small molecule inhibitor of the anti-apoptotic protein Bcl-2, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C103147"
+      },
+      {
+        "value": "Doxorubicin",
+        "description": "An anthracycline antibiotic with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C456"
+      },
+      {
+        "value": "BI 2536",
+        "description": "A small molecule compound with potential antineoplastic activities. BI 2536 binds to and inhibits Polo-like kinase 1 (Plk1), resulting in mitotic arrest, disruption of cytokinesis, and apoptosis in susceptible tumor cell populations.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C49091"
+      },
+      {
+        "value": "Bortezomib",
+        "description": "A dipeptide boronic acid analogue with antineoplastic activity. Bortezomib reversibly inhibits the 26S proteasome, a large protease complex that degrades ubiquinated proteins.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1851"
+      },
+      {
+        "value": "Carfilzomib",
+        "description": "An epoxomicin derivate with potential antineoplastic activity. Carfilzomib irreversibly binds to and inhibits the chymotrypsin-like activity of the 20S catalytic core subunit of the proteasome, a protease complex responsible for degrading a large variety of cellular proteins.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C52196"
+      },
+      {
+        "value": "Culture Medium",
+        "description": "A liquid or gel containing nutrients, salts, and other factors formulated to support the growth of microorganisms, cells, or plants.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C85504"
+      },
+      {
+        "value": "CPD22",
+        "description": "A novel ILK inhibitor, which exhibit[s] high in vitro potency against a panel of prostate and breast cancer cell lines.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/21823616"
+      },
+      {
+        "value": "Crizotinib",
+        "description": "An orally available aminopyridine-based inhibitor of the receptor tyrosine kinase anaplastic lymphoma kinase (ALK) and the c-Met/hepatocyte growth factor receptor (HGFR) with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74061"
+      },
+      {
+        "value": "Curcumin",
+        "description": "A phytopolylphenol pigment isolated from the plant Curcuma longa, commonly known as turmeric, with a variety of pharmacologic properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C401"
+      },
+      {
+        "value": "Daratumumab",
+        "description": "A fully human monoclonal antibody directed against the cell surface glycoprotein CD-38 with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74007"
+      },
+      {
+        "value": "Defactinib",
+        "description": "An orally bioavailable, small-molecule focal adhesion kinase (FAK) inhibitor with potential antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C79809"
+      },
+      {
+        "value": "Dexamethasone",
+        "description": "A synthetic adrenal corticosteroid with potent anti-inflammatory properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C422"
+      },
+      {
+        "value": "Dinaciclib",
+        "description": "A pyrazolo[1,5-a]pyrimidine with potential antineoplastic activity. Dinaciclib selectively inhibits cyclin dependent kinases CDK1, CDK2, CDK5, and CDK9.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C78854"
+      },
+      {
+        "value": "DMSO",
+        "description": "A highly polar organic liquid that is used widely as a chemical solvent and a free radical scavenger.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C437"
+      },
+      {
+        "value": "GGTI-2418",
+        "description": "A potent and selective peptidomimetic inhibitor of geranylgeranyltransferase I (GGTI).",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/19204084"
+      },
+      {
+        "value": "INCB054329",
+        "description": "An inhibitor of the Bromodomain and Extra-Terminal (BET) family of bromodomain-containing proteins with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C121948"
+      },
+      {
+        "value": "IRAK-1/4 Inhibitor",
+        "description": "Interleukin-1 Receptor-Associated-Kinase-1/4 Inhibitor.",
+        "source": "https://pubchem.ncbi.nlm.nih.gov/compound/IRAK-1_4_Inhibitor"
+      },
+      {
+        "value": "IgG",
+        "description": "An immunoglobulin isotype (subclass) that characterizes secondary immune responses.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C568"
+      },
+      {
+        "value": "Ixazomib",
+        "description": "An active metabolite of MLN9708, a second generation, boron containing peptide proteasome inhibitor (PI) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C97940"
+      },
+      {
+        "value": "Selinexor",
+        "description": "An orally available, small molecule inhibitor of CRM1 (chromosome region maintenance 1 protein, exportin 1 or XPO1), with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C102546"
+      },
+      {
+        "value": "Lenalidomide",
+        "description": "A thalidomide analog with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C2668"
+      },
+      {
+        "value": "MA7-038",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "Melphalan",
+        "description": "A phenylalanine derivative of nitrogen mustard with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C633"
+      },
+      {
+        "value": "MK2206",
+        "description": "An orally bioavailable allosteric inhibitor of the serine/threonine protein kinase Akt (protein kinase B) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C90581"
+      },
+      {
+        "value": "MTI-101",
+        "description": "MTI-101 (cyclized HYD1) binds a CD44 containing complex.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/24048737"
+      },
+      {
+        "value": "Panobinostat",
+        "description": "A cinnamic hydroxamic acid analogue with potential antineoplastic activity. Panobinostat selectively inhibits histone deacetylase (HDAC).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C66948"
+      },
+      {
+        "value": "Pomalidomide",
+        "description": "An orally bioavailable derivative of thalidomide with potential immunomodulating, antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C72560"
+      },
+      {
+        "value": "Ponatinib",
+        "description": "An orally bioavailable multitargeted receptor tyrosine kinase (RTK) inhibitor with potential antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C95777"
+      },
+      {
+        "value": "Ricolinostat",
+        "description": "An orally bioavailable, specific inhibitor of histone deacetylase 6 (HDAC6) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C96431"
+      },
+      {
+        "value": "Silmitasertib",
+        "description": "Silmitasertib selectively binds to and inhibits the enzyme casein kinase II (CK2)",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C98054"
+      },
+      {
+        "value": "SNS-032",
+        "description": "A small aminothiazole molecule and cyclin dependent kinase (CDK) inhibitor with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C62523"
+      },
+      {
+        "value": "SR-3029",
+        "description": "Highly selective casein kinase 1delta/1epsilon inhibitor with potent antiproliferative properties.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/67585785"
+      },
+      {
+        "value": "THZ1",
+        "description": "A low nanomolar inhibitor of cell proliferation and biochemical CDK7 activity.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4244910/"
+      },
+      {
+        "value": "UMI-77",
+        "description": "An Mcl-1 inhibitor.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/2003359"
+      },
+      {
+        "value": "Volasertib",
+        "description": "A dihydropteridinone Polo-like kinase 1 (Plk1) inhibitor with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C79844"
+      },
+      {
+        "value": "Fimepinostat",
+        "description": "An orally bioavailable inhibitor of both phosphoinositide 3-kinase (PI3K) class I and pan histone deacetylase (HDAC) enzymes, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C104008"
+      },
+      {
+        "value": "Brigatinib",
+        "description": "An orally available inhibitor of receptor tyrosine kinases anaplastic lymphoma kinase (ALK) and the epidermal growth factor receptor (EGFR) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C98831"
+      },
+      {
+        "value": "Omipalisib",
+        "description": "A small-molecule pyridylsulfonamide inhibitor of phosphatidylinositol 3-kinase (PI3K) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88270"
+      },
+      {
+        "value": "Simvastatin",
+        "description": "A lipid-lowering agent derived synthetically from a fermentation product of the fungus Aspergillus terreus.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C29454"
+      },
+      {
+        "value": "Dasatinib",
+        "description": "An orally bioavailable synthetic small molecule-inhibitor of SRC-family protein-tyrosine kinases.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C38713"
+      },
+      {
+        "value": "Sapanisertib",
+        "description": "An orally bioavailable inhibitor of raptor-mTOR (TOR complex 1 or TORC1) and rictor-mTOR (TOR complex 2 or TORC2) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C90548"
+      },
+      {
+        "value": "AR-42",
+        "description": "An orally available phenylbutyrate-derived histone deacetylase (HDAC) inhibitor, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C116850"
+      },
+      {
+        "value": "Axitinib",
+        "description": "http://purl.obolibrary.org/obo/NCIT_C38718",
+        "source": "An orally bioavailable tyrosine kinase inhibitor."
+      },
+      {
+        "value": "Selumetinib",
+        "description": "An orally active, small molecule with potential antineoplastic activity. Selumetinib is an ATP-independent inhibitor of mitogen-activated protein kinase kinase (MEK or MAPK/ERK kinase) 1 and 2.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C66939"
+      },
+      {
+        "value": "Lapatinib",
+        "description": "A synthetic, orally-active quinazoline with potential antineoplastic properties. Lapatinib reversibly blocks phosphorylation of the epidermal growth factor receptor (EGFR), ErbB2, and the Erk-1 and-2 and AKT kinases; it also inhibits cyclin D protein levels in human tumor cell lines and xenografts",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C26653"
+      },
+      {
+        "value": "Vistusertib",
+        "description": "An orally bioavailable inhibitor of the mammalian target of rapamycin (mTOR) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88329"
+      },
+      {
+        "value": "Ganetespib",
+        "description": "A synthetic small-molecule inhibitor of heat shock protein 90 (Hsp90) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C77872"
+      },
+      {
+        "value": "Galunisertib",
+        "description": "An orally available, small molecule antagonist of the tyrosine kinase transforming growth factor-beta (TGF-b) receptor type 1 (TGFBR1), with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C116891"
+      },
+      {
+        "value": "GDC-0941 Bismesylate",
+        "description": "The orally bioavailable bismesylate salt of a potent small-molecule thieno[3,2-d]pyrimidine inhibitor of the class I phosphatidylinositol 3 kinase (PI3K) isoforms p100alpha and p100delta with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C82380"
+      },
+      {
+        "value": "Vismodegib",
+        "description": "An orally bioavailable small molecule with potential antineoplastic activity. Hedgehog antagonist GDC-0449 targets the Hedgehog signaling pathway, blocking the activities of the Hedgehog-ligand cell surface receptors PTCH and/or SMO and suppressing Hedgehog signaling. ",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74038"
+      },
+      {
+        "value": "AR-12",
+        "description": "An orally bioavailable, small-molecule, celecoxib-derived inhibitor of phosphoinositide-dependent kinase-1 (PDK1) with potential antineoplastic activity. Devoid of any COX inhibiting activity, PDK1 inhibitor AR-12 binds to and inhibits the phosphorylation of 3-phosphoinositide-dependent kinase-1 (PDK-1).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88271"
+      },
+      {
+        "value": "Everolimus",
+        "description": "A derivative of the natural macrocyclic lactone sirolimus with immunosuppressant and anti-angiogenic properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C48387"
+      },
+      {
+        "value": "Vorinostat",
+        "description": "A synthetic hydroxamic acid derivative with antineoplastic activity. Vorinostat, a second generation polar-planar compound, binds to the catalytic domain of the histone deacetylases (HDACs).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1796"
+      },
+      {
+        "value": "Perifosine",
+        "description": "An orally active alkyl-phosphocholine compound with potential antineoplastic activity. Targeting cellular membranes, perifosine modulates membrane permeability, membrane lipid composition, phospholipid metabolism, and mitogenic signal transduction, resulting in cell differentiation and inhibition of cell growth.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1727"
+      },
+      {
+        "value": "Trametinib",
+        "description": "An orally bioavailable inhibitor of mitogen-activated protein kinase kinase (MEK MAPK/ERK kinase) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C77908"
+      },
+      {
+        "value": "GDC-0980",
+        "description": "An orally available agent targeting phosphatidylinositol 3 kinase (PI3K) and mammalian target of rapamycin (mTOR) kinase in the PI3K/mTOR signaling pathway, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C91731"
+      }
+    ] 
+  },
+  {
+    "name": "secondCompoundName",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "A-1210477",
+        "description": "An MCL-1 inhibitor.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/2015744"
+      },
+      {
+        "value": "ABBVIE1",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE2",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE3",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE4",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE5",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE6",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE7",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "ABBVIE8",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "Venetoclax",
+        "description": "An orally bioavailable, selective small molecule inhibitor of the anti-apoptotic protein Bcl-2, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C103147"
+      },
+      {
+        "value": "Doxorubicin",
+        "description": "An anthracycline antibiotic with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C456"
+      },
+      {
+        "value": "BI 2536",
+        "description": "A small molecule compound with potential antineoplastic activities. BI 2536 binds to and inhibits Polo-like kinase 1 (Plk1), resulting in mitotic arrest, disruption of cytokinesis, and apoptosis in susceptible tumor cell populations.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C49091"
+      },
+      {
+        "value": "Bortezomib",
+        "description": "A dipeptide boronic acid analogue with antineoplastic activity. Bortezomib reversibly inhibits the 26S proteasome, a large protease complex that degrades ubiquinated proteins.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1851"
+      },
+      {
+        "value": "Carfilzomib",
+        "description": "An epoxomicin derivate with potential antineoplastic activity. Carfilzomib irreversibly binds to and inhibits the chymotrypsin-like activity of the 20S catalytic core subunit of the proteasome, a protease complex responsible for degrading a large variety of cellular proteins.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C52196"
+      },
+      {
+        "value": "Culture Medium",
+        "description": "A liquid or gel containing nutrients, salts, and other factors formulated to support the growth of microorganisms, cells, or plants.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C85504"
+      },
+      {
+        "value": "CPD22",
+        "description": "A novel ILK inhibitor, which exhibit[s] high in vitro potency against a panel of prostate and breast cancer cell lines.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/21823616"
+      },
+      {
+        "value": "Crizotinib",
+        "description": "An orally available aminopyridine-based inhibitor of the receptor tyrosine kinase anaplastic lymphoma kinase (ALK) and the c-Met/hepatocyte growth factor receptor (HGFR) with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74061"
+      },
+      {
+        "value": "Curcumin",
+        "description": "A phytopolylphenol pigment isolated from the plant Curcuma longa, commonly known as turmeric, with a variety of pharmacologic properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C401"
+      },
+      {
+        "value": "Daratumumab",
+        "description": "A fully human monoclonal antibody directed against the cell surface glycoprotein CD-38 with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74007"
+      },
+      {
+        "value": "Defactinib",
+        "description": "An orally bioavailable, small-molecule focal adhesion kinase (FAK) inhibitor with potential antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C79809"
+      },
+      {
+        "value": "Dexamethasone",
+        "description": "A synthetic adrenal corticosteroid with potent anti-inflammatory properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C422"
+      },
+      {
+        "value": "Dinaciclib",
+        "description": "A pyrazolo[1,5-a]pyrimidine with potential antineoplastic activity. Dinaciclib selectively inhibits cyclin dependent kinases CDK1, CDK2, CDK5, and CDK9.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C78854"
+      },
+      {
+        "value": "DMSO",
+        "description": "A highly polar organic liquid that is used widely as a chemical solvent and a free radical scavenger.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C437"
+      },
+      {
+        "value": "GGTI-2418",
+        "description": "A potent and selective peptidomimetic inhibitor of geranylgeranyltransferase I (GGTI).",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/19204084"
+      },
+      {
+        "value": "INCB054329",
+        "description": "An inhibitor of the Bromodomain and Extra-Terminal (BET) family of bromodomain-containing proteins with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C121948"
+      },
+      {
+        "value": "IRAK-1/4 Inhibitor",
+        "description": "Interleukin-1 Receptor-Associated-Kinase-1/4 Inhibitor.",
+        "source": "https://pubchem.ncbi.nlm.nih.gov/compound/IRAK-1_4_Inhibitor"
+      },
+      {
+        "value": "IgG",
+        "description": "An immunoglobulin isotype (subclass) that characterizes secondary immune responses.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C568"
+      },
+      {
+        "value": "Ixazomib",
+        "description": "An active metabolite of MLN9708, a second generation, boron containing peptide proteasome inhibitor (PI) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C97940"
+      },
+      {
+        "value": "Selinexor",
+        "description": "An orally available, small molecule inhibitor of CRM1 (chromosome region maintenance 1 protein, exportin 1 or XPO1), with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C102546"
+      },
+      {
+        "value": "Lenalidomide",
+        "description": "A thalidomide analog with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C2668"
+      },
+      {
+        "value": "MA7-038",
+        "description": "Internal research compound.",
+        "source": "Moffitt"
+      },
+      {
+        "value": "Melphalan",
+        "description": "A phenylalanine derivative of nitrogen mustard with antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C633"
+      },
+      {
+        "value": "MK2206",
+        "description": "An orally bioavailable allosteric inhibitor of the serine/threonine protein kinase Akt (protein kinase B) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C90581"
+      },
+      {
+        "value": "MTI-101",
+        "description": "MTI-101 (cyclized HYD1) binds a CD44 containing complex.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/24048737"
+      },
+      {
+        "value": "Panobinostat",
+        "description": "A cinnamic hydroxamic acid analogue with potential antineoplastic activity. Panobinostat selectively inhibits histone deacetylase (HDAC).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C66948"
+      },
+      {
+        "value": "Pomalidomide",
+        "description": "An orally bioavailable derivative of thalidomide with potential immunomodulating, antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C72560"
+      },
+      {
+        "value": "Ponatinib",
+        "description": "An orally bioavailable multitargeted receptor tyrosine kinase (RTK) inhibitor with potential antiangiogenic and antineoplastic activities.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C95777"
+      },
+      {
+        "value": "Ricolinostat",
+        "description": "An orally bioavailable, specific inhibitor of histone deacetylase 6 (HDAC6) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C96431"
+      },
+      {
+        "value": "Silmitasertib",
+        "description": "Silmitasertib selectively binds to and inhibits the enzyme casein kinase II (CK2)",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C98054"
+      },
+      {
+        "value": "SNS-032",
+        "description": "A small aminothiazole molecule and cyclin dependent kinase (CDK) inhibitor with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C62523"
+      },
+      {
+        "value": "SR-3029",
+        "description": "Highly selective casein kinase 1delta/1epsilon inhibitor with potent antiproliferative properties.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/67585785"
+      },
+      {
+        "value": "THZ1",
+        "description": "A low nanomolar inhibitor of cell proliferation and biochemical CDK7 activity.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4244910/"
+      },
+      {
+        "value": "UMI-77",
+        "description": "An Mcl-1 inhibitor.",
+        "source": "https://www.ncbi.nlm.nih.gov/mesh/2003359"
+      },
+      {
+        "value": "Volasertib",
+        "description": "A dihydropteridinone Polo-like kinase 1 (Plk1) inhibitor with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C79844"
+      },
+      {
+        "value": "Fimepinostat",
+        "description": "An orally bioavailable inhibitor of both phosphoinositide 3-kinase (PI3K) class I and pan histone deacetylase (HDAC) enzymes, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C104008"
+      },
+      {
+        "value": "Brigatinib",
+        "description": "An orally available inhibitor of receptor tyrosine kinases anaplastic lymphoma kinase (ALK) and the epidermal growth factor receptor (EGFR) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C98831"
+      },
+      {
+        "value": "Omipalisib",
+        "description": "A small-molecule pyridylsulfonamide inhibitor of phosphatidylinositol 3-kinase (PI3K) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88270"
+      },
+      {
+        "value": "Simvastatin",
+        "description": "A lipid-lowering agent derived synthetically from a fermentation product of the fungus Aspergillus terreus.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C29454"
+      },
+      {
+        "value": "Dasatinib",
+        "description": "An orally bioavailable synthetic small molecule-inhibitor of SRC-family protein-tyrosine kinases.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C38713"
+      },
+      {
+        "value": "Sapanisertib",
+        "description": "An orally bioavailable inhibitor of raptor-mTOR (TOR complex 1 or TORC1) and rictor-mTOR (TOR complex 2 or TORC2) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C90548"
+      },
+      {
+        "value": "AR-42",
+        "description": "An orally available phenylbutyrate-derived histone deacetylase (HDAC) inhibitor, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C116850"
+      },
+      {
+        "value": "Axitinib",
+        "description": "http://purl.obolibrary.org/obo/NCIT_C38718",
+        "source": "An orally bioavailable tyrosine kinase inhibitor."
+      },
+      {
+        "value": "Selumetinib",
+        "description": "An orally active, small molecule with potential antineoplastic activity. Selumetinib is an ATP-independent inhibitor of mitogen-activated protein kinase kinase (MEK or MAPK/ERK kinase) 1 and 2.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C66939"
+      },
+      {
+        "value": "Lapatinib",
+        "description": "A synthetic, orally-active quinazoline with potential antineoplastic properties. Lapatinib reversibly blocks phosphorylation of the epidermal growth factor receptor (EGFR), ErbB2, and the Erk-1 and-2 and AKT kinases; it also inhibits cyclin D protein levels in human tumor cell lines and xenografts",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C26653"
+      },
+      {
+        "value": "Vistusertib",
+        "description": "An orally bioavailable inhibitor of the mammalian target of rapamycin (mTOR) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88329"
+      },
+      {
+        "value": "Ganetespib",
+        "description": "A synthetic small-molecule inhibitor of heat shock protein 90 (Hsp90) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C77872"
+      },
+      {
+        "value": "Galunisertib",
+        "description": "An orally available, small molecule antagonist of the tyrosine kinase transforming growth factor-beta (TGF-b) receptor type 1 (TGFBR1), with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C116891"
+      },
+      {
+        "value": "GDC-0941 Bismesylate",
+        "description": "The orally bioavailable bismesylate salt of a potent small-molecule thieno[3,2-d]pyrimidine inhibitor of the class I phosphatidylinositol 3 kinase (PI3K) isoforms p100alpha and p100delta with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C82380"
+      },
+      {
+        "value": "Vismodegib",
+        "description": "An orally bioavailable small molecule with potential antineoplastic activity. Hedgehog antagonist GDC-0449 targets the Hedgehog signaling pathway, blocking the activities of the Hedgehog-ligand cell surface receptors PTCH and/or SMO and suppressing Hedgehog signaling. ",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C74038"
+      },
+      {
+        "value": "AR-12",
+        "description": "An orally bioavailable, small-molecule, celecoxib-derived inhibitor of phosphoinositide-dependent kinase-1 (PDK1) with potential antineoplastic activity. Devoid of any COX inhibiting activity, PDK1 inhibitor AR-12 binds to and inhibits the phosphorylation of 3-phosphoinositide-dependent kinase-1 (PDK-1).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C88271"
+      },
+      {
+        "value": "Everolimus",
+        "description": "A derivative of the natural macrocyclic lactone sirolimus with immunosuppressant and anti-angiogenic properties.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C48387"
+      },
+      {
+        "value": "Vorinostat",
+        "description": "A synthetic hydroxamic acid derivative with antineoplastic activity. Vorinostat, a second generation polar-planar compound, binds to the catalytic domain of the histone deacetylases (HDACs).",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1796"
+      },
+      {
+        "value": "Perifosine",
+        "description": "An orally active alkyl-phosphocholine compound with potential antineoplastic activity. Targeting cellular membranes, perifosine modulates membrane permeability, membrane lipid composition, phospholipid metabolism, and mitogenic signal transduction, resulting in cell differentiation and inhibition of cell growth.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C1727"
+      },
+      {
+        "value": "Trametinib",
+        "description": "An orally bioavailable inhibitor of mitogen-activated protein kinase kinase (MEK MAPK/ERK kinase) with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C77908"
+      },
+      {
+        "value": "GDC-0980",
+        "description": "An orally available agent targeting phosphatidylinositol 3 kinase (PI3K) and mammalian target of rapamycin (mTOR) kinase in the PI3K/mTOR signaling pathway, with potential antineoplastic activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C91731"
+      }
+    ] 
+  },
+  {
+    "name": "drugScreenType",
+    "description": "String describing general class of drug screen",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues":[
+      {
+        "value": "singleMolecule",
+        "description": "An experiment in which a single molecule was used in an assay",
+        "source": ""
+      },
+      {
+        "value": "smallMoleculeLibraryScreen",
+        "description": "High throughput sample analysis of small molecules for purpose such as drug discovery, or biochemical, genetic or pharmacological tests.",
+        "source": " http://purl.obolibrary.org/obo/ERO_0001726"
+      },
+      {
+        "value":"combinationLibraryScreen",
+        "description":"High throughput sample analysis of collections of compounds that provide a variety of chemically diverse structures that can be used to identify structure types that have affinity with pharmacological targets.",
+        "source":"http://purl.obolibrary.org/obo/ERO_0001686"
+      },
+      {
+        "value": "combinationScreen",
+        "description":"",
+        "source":""
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/curatedData.json
+++ b/synapseAnnotations/json_schema/ontology/curatedData.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "curatedDataType",
+    "description": "The type of information being curated.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "reference sequence",
+        "description": "Syntactic sequences that has a role as reference of an annotation.",
+        "source": "http://rdf.biosemantics.org/ontologies/rsa#ReferenceSequence"
+      },
+      {
+        "value": "gene symbol",
+        "description": "A unique gene name approved by an organism specific nomenclature committee.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C43568"
+      },
+      {
+        "value": "clinical data",
+        "description": "Data obtained through patient examination or treatment.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C15783"
+      },
+      {
+        "value": "gene function",
+        "description": "A term that expresses the function of a gene product.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C48933"
+      },
+      {
+        "value": "chemical descriptor",
+        "description": "A chemical descriptor is a data item (quantity or value) about a chemical entity that conforms to a specification for how it is calculated, measured or recorded.",
+        "source": "http://semanticscience.org/resource/CHEMINF_000123"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/dhart.json
+++ b/synapseAnnotations/json_schema/ontology/dhart.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "projectNumber", 
+    "description": "There are four projects on going in the spore. This describes for which one the data was collected.", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Project 1",
+        "description": "The Plexiform NF project led",
+        "source": ""
+      },
+      {
+        "value": "Project 2",
+        "description": "The MPNST project",
+        "source": ""
+      },
+      {
+        "value": "Project 3",
+        "description": "The JMML project",
+        "source": ""
+      },
+      {
+        "value": "Project 4",
+        "description": "The NF1 survivor project",
+        "source": ""
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/experimentalData.json
+++ b/synapseAnnotations/json_schema/ontology/experimentalData.json
@@ -1,0 +1,1179 @@
+[
+  {
+    "name": "assay",
+    "description": "The technology used to generate the data in this file",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "immunohistochemistry",
+        "description": "An immunostaining assay to detect and potentially localize antigens within the cells of a tissue section",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001986"},
+      {
+        "value": "NOMe-Seq",
+        "description": "Nucleosome Occupancy and Methylome Sequencing",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C106053"
+      },
+      {
+        "value": "FIA-MSMS",
+        "description": "Flow injection analysis - tandem mass spectrometer",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmed/28667829"
+      },
+      {
+        "value": "UPLC-MSMS",
+        "description": "Ultra performance liquid chromatography - tandem mass spectrometer.",
+        "source": "https://www.wur.nl/en/show/Ultra-performance-liquid-chromatography-tandem-mass-spectrometer-UPLCMSMS.htm"
+      },
+      {
+        "value": "rnaSeq",
+        "description": "RNA Sequencing measurements",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001271"
+      },
+      {
+        "value": "mirnaSeq",
+        "description": "Small RNA measurements collected from RNA-Seq experiments",
+        "source": "http://purl.obolibrary.org/obo/OBI_0002112"
+      },
+      {
+        "value": "LC-MSMS",
+        "description": "A method where a sample mixture is first separated by liquid chromatography before being ionised and characterised by mass-to-charge ratio and relative abundance using two mass spectrometers in series",
+        "source": "http://purl.obolibrary.org/obo/CHMO_0000701"
+      },
+      {
+        "value": "LC-MS",
+        "description": "A method where a sample mixture is first separated by liquid chromatography before being converted into ions which are characterised by their mass-to-charge ratio and relative abundance",
+        "source": "http://purl.obolibrary.org/obo/CHMO_0000524"
+      },
+      {
+        "value": "lncrnaSeq",
+        "description": "Long non-coding RNA measurements collected from RNA-Seq experiments",
+        "source": ""
+      },
+      {
+        "value": "exomeSeq",
+        "description": "Data derived from exome sequencing",
+        "source": "http://purl.obolibrary.org/obo/OBI_0002118"
+      },
+      {
+        "value": "ChIPSeq",
+        "description": "Chromatin immuno-precipitation followed by sequencing",
+        "source": "http://purl.obolibrary.org/obo/OBI_0000716"
+      },
+      {
+        "value": "rnaArray",
+        "description": "RNA measurements captured by array technology",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001463"
+      },
+      {
+        "value": "snpArray",
+        "description": "SNP measurements captured by array technology",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001204"
+      },
+      {
+        "value": "methylationArray",
+        "description": "Methylation data captured by array technology",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001332"
+      },
+      {
+        "value": "mirnaArray",
+        "description": "microRNA measurements captured by array technology",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001335"
+      },
+      {
+        "value": "bisulfiteSeq",
+        "description": "Methylation data captured by sequencing of DNA treated by a bisulfite-based chemical process",
+        "source": "http://purl.obolibrary.org/obo/OBI_0000748"
+      },
+      {
+        "value": "ATACSeq",
+        "description": "Open chromatin regions measured by sequencing DNA after assay for transposase-accessible chromatin (ATAC) treatment",
+        "source": "http://purl.obolibrary.org/obo/OBI_0002039"
+      },
+      {
+        "value": "HI-C",
+        "description": "Chromatin interactions detected by HI-C protocol",
+        "source": "http://www.ebi.ac.uk/efo/EFO_0007693"
+      },
+      {
+        "value": "errBisulfiteSeq",
+        "description": "Data for enriched reduced representation bisulfite sequencing data",
+        "source": ""
+      },
+      {
+        "value": "ISOSeq",
+        "description": "Full isoform sequencing",
+        "source": ""
+      },
+      {
+        "value": "MRI",
+        "description": "Techniques that uses magnetic fields and radiowaves to form images, typically to investigate the anatomy and physiology of the human body.",
+        "source": "http://edamontology.org/topic_3444"
+      },
+      {
+        "value": "westernBlot",
+        "description": "A multistep process in which a mixture of proteins is separated by gel electrophoresis",
+        "source": "http://purl.obolibrary.org/obo/MMO_0000338"
+      },
+      {
+        "value": "wholeGenomeSeq",
+        "description": "Laboratory technique to sequence the complete DNA sequence of an organism's genome at a single time",
+        "source": "http://edamontology.org/topic_3673"
+      },
+      {
+        "value": "polymeraseChainReaction",
+        "description": "A rapid technique for in vitro amplification of specific DNA or RNA sequences, allowing small quantities of short sequences to be analyzed without cloning",
+        "source": "http://purl.obolibrary.org/obo/MMO_0000459"
+      },
+      {
+        "value": "cellViabilityAssay",
+        "description": "This assay type measures the cellular state of living or dying by measuring an indicator of life or death",
+        "source": "http://www.bioassayontology.org/bao#BAO_0003009"
+      },
+      {
+        "value": "atomicForceMicroscopy",
+        "description": "Microscopy which uses a sharp spike (known as a 'tip') mounted on the end of a cantilever to scan the surface of the specimen",
+        "source": "http://purl.obolibrary.org/obo/CHMO_0000113"
+      },
+      {
+        "value": "brightfieldMicroscopy",
+        "description": "Microscopy where the specimen is illuminated with light transmitted from a source on the opposite side of the specimen from the objective",
+        "source": "http://purl.obolibrary.org/obo/CHMO_0000104"
+      },
+      {
+        "value": "tractionForceMicroscopy",
+        "description": "An experimental method for determining the tractions on the surface of a biological cell by obtaining measurements of the surrounding displacement field within an in vitro extracellular matrix (ECM)",
+        "source": "https://en.wikipedia.org/wiki/Traction_force_microscopy"
+      },
+      {
+        "value": "nextGenerationTargetedSequencing",
+        "description": "A type of next generation sequencing in which specific genes or portions of genes are targeted for sequencing using amplicon-based workflow.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C130177"
+      },
+      {
+        "value": "jumpingLibrary",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "MIB/MS",
+        "description": "Kinomics assay using multiplexed kinase inhibitor beads and mass spectrometry (MIB/MS)",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3328787/"
+      },
+      {
+        "value": "MudPIT",
+        "description": "MudPIT is a method for rapid and large-scale protein identification by multidimensional liquid chromatography associated with tandem mass spectrometry",
+        "source": "http://purl.obolibrary.org/obo/MI_0658"
+      },
+      {
+        "value": "questionnaire",
+        "description": "A document with a set of printed or written questions with a choice of answers, devised for the purposes of a survey or statistical study.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001000"
+      },
+      {
+        "value": "novelty response behavior",
+        "description": "Behavior related to the exploration/investigation of a novel object, situation or environment.",
+        "source": "http://purl.obolibrary.org/obo/NBO_0000086"
+      },
+      {
+        "value": "active avoidance learning behavior",
+        "description": "Avoidance learning when the action occurs.",
+        "source": "http://purl.obolibrary.org/obo/NBO_0000217"
+      }
+    ]
+  },
+  {
+    "name": "dataSubtype",
+    "description": "Further qualification of dataType, which may be used to indicate the state of processing of the data, aggregation of the data, or presence of metadata.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "dataMatrix",
+        "description": "A file of data containing multiple values for multiple samples.",
+        "source": ""
+      },
+      {
+        "value": "raw",
+        "description": "A data file produced by an instrument, or one with very little subsequent processing.",
+        "source": ""
+      },
+      {
+        "value": "processed",
+        "description": "A file of data generated from running one or more bioinformatics methods on a raw file.",
+        "source": ""
+      },
+      {
+        "value": "metadata",
+        "description": "A file of clinical, technical, or other parameters that describe a dataset.",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "organ",
+    "description": "A unique macroscopic (gross) anatomic structure that performs specific functions. It is composed of various tissues. An organ is part of an anatomic system or a body region.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "skin",
+        "description": "The integument of an animal (as a fur-bearing mammal or a bird) separated from the body usually with its hair or feathers.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0001253"
+      },
+      {
+        "value": "nerves",
+        "description": "Any of the filamentous bands of nervous tissue that connect parts of the nervous system with the other organs, conduct nervous impulses, and are made up of axons and dendrites together with protective and supportive structures.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000925"
+      },
+      {
+        "value": "brain",
+        "description": "The portion of the vertebrate central nervous system that constitutes the organ of thought and neural coordination.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000142"
+      },
+      {
+        "value": "blood",
+        "description": "The fluid that circulates in the heart, arteries, capillaries, and veins of a vertebrate animal carrying nourishment and oxygen to and bringing away waste products from all parts of the body.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000089"
+      },
+      {
+        "value": "breast",
+        "description": "The fore or ventral part of the body between the neck and the abdomen.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000149"
+      },
+      {
+        "value": "colon",
+        "description": "The part of the large intestine that extends from the cecum to the rectum.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000269"
+      },
+      {
+        "value": "lung",
+        "description": "One of the usually paired compound saccular thoracic organs that constitute the basic respiratory organ of air-breathing vertebrates.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000763"
+      },
+      {
+        "value": "prostate",
+        "description": "Lobular organ the parenchyma of which has as its parts glandular acini which are continuous with the prostatic part of the urethra.",
+        "source": "http://purl.obolibrary.org/obo/FMA_9600"
+      },
+      {
+        "value": "pancreas",
+        "description": "A large lobulated gland of vertebrates that secretes digestive enzymes and the hormones insulin and glucagon.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000988"
+      },
+      {
+        "value": "ovary",
+        "description": "One of the typically paired essential female reproductive organs that produce eggs and in vertebrates female sex hormones.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000975"
+      },
+      {
+        "value": "spleen",
+        "description": "A highly vascular ductless organ that is located in the left abdominal region near the stomach or intestine of most vertebrates and is concerned with final destruction of red blood cells, filtration and storage of blood, and production of lymphocytes.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0001281"
+      },
+      {
+        "value": "bone marrow",
+        "description": "The soft, fatty, vascular tissue that fills most bone cavities and is the source of red blood cells and many white blood cells.",
+        "source": "http://purl.obolibrary.org/obo/BTO_0000141"
+      }
+    ]
+  },
+  {
+    "name": "dataType",
+    "description": "Types of input/output data in bioinformatics pipelines",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "genomicVariants",
+        "description": "Genomic alterations, including single nucleotide polymorphisms, short indels and structural variants, in a genome sequence.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Foperation_3227"
+      },
+      {
+        "value": "metabolomics",
+        "description": "The systematic study of metabolites, the chemical processes they are involved, and the chemical fingerprints of specific cellular processes in a whole cell, tissue, organ or organism.",
+        "source": "http://edamontology.org/topic_3172"
+      },
+      {
+        "value": "image",
+        "description": "Biological or biomedical data that has been rendered into an image.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fdata_2968"
+      },
+      {
+        "value": "geneExpression",
+        "description": "The analysis of levels and patterns of synthesis of gene products (proteins and functional RNA) including interpretation in functional terms of gene expression data.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0203"
+      },
+      {
+        "value": "isoformExpression",
+        "description": "Expression of protien isoforms formed from alternative splicings or other post-translational modifications of a single gene through RNA splicing mechanisms.",
+        "source": "https://en.wikipedia.org/wiki/Protein_isoform"
+      },
+      {
+        "value": "proteomics",
+        "description": "Protein and peptide identification, especially in the study of whole proteomes of organisms.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0121"
+      },
+      {
+        "value": "kinomics",
+        "description": "Kinomics is the study of protein kinases and protein kinase signaling.",
+        "source": "http://www.kinomecore.com/what-is-kinomics/"
+      },
+      {
+        "value": "drugScreen",
+        "description": "Information on drug sensitivity and molecular markers of drug response",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531057/"
+      },
+      {
+        "value": "cellularPhysiology",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "chromatinActivity",
+        "description": "Chromatin activity that allow access of condensed genomic DNA and potentially control gene expression.",
+        "source": "https://en.wikipedia.org/wiki/Chromatin_remodeling"
+      },
+      {
+        "value": "surveyData",
+        "description": "A data set that contains the outcome of a survey.",
+        "source": "http://purl.obolibrary.org/obo/OMIABIS_0000060"
+      },
+      {
+        "value": "network",
+        "description":"An interconnected system of things or people.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C61377"
+      }
+    ]
+  },
+  {
+    "name": "individualIdSource",
+    "description": "Database or repository to which individual ID maps",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "NIMH-HBCC",
+        "description": "The NIH Human Brain Collection Core",
+        "source": "https://www.nimh.nih.gov/labs-at-nimh/research-areas/research-support-services/hbcc/human-brain-collection-core-hbcc.shtml"
+      },
+      {
+        "value": "MSSM",
+        "description": "Mount Sinai NIH Brain and Tissue Repository",
+        "source": "http://icahn.mssm.edu/research/labs/neuropathology-and-brain-banking"
+      },
+      {
+        "value": "Penn",
+        "description": "The University of Pennsylvania Alzheimer's Disease Core Center (ADCC), Penn Udall Center and the Center for Neurodegenerative Disease Research (CNDR)",
+        "source": "http://www.med.upenn.edu/cndr/biosamples-brainbank.html"
+      },
+      {
+        "value": "Pitt",
+        "description": "The University of Pittsburgh NIH NeuroBioBank Brain and Tissue Repository",
+        "source": "https://neurobiobank.nih.gov/"
+      }
+    ]
+  },
+  {
+    "name": "tissue",
+    "description": "A tissue is a mereologically maximal collection of cells that together perform physiological function.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "medial orbital frontal cortex",
+        "description": "Component of the orbtial frontal cortex.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0022352"
+      },
+      {
+        "value": "medial prefrontal cortex",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "medial dorsal nucleus of thalamus",
+        "description": "A large nucleus in the thalamus. It receives inputs from the Pre-Frontal Cortex and the Limbic System and in turn relays them to the Pre-Frontal Association Cortex. ",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002739"
+      },
+      {
+        "value": "inferior temporal cortex",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "posterior inferior parietal cortex",
+        "description": "",
+        "source": "Sage Bionetworks"},
+      {
+        "value": "midbrain",
+        "description": "the middle division of the three primary divisions of the developing chordate brain or the corresponding part of the adult brain (in vertebrates, includes a ventral part containing the cerebral peduncles and a dorsal tectum containing the corpora quadrigemina and that surrounds the aqueduct of Sylvius connecting the third and fourth ventricles.",
+        "source": "http://purl.obolibrary.org/obo/UBERON_0001891"
+      },
+      {
+        "value": "cerebral cortex",
+        "description": "The thin layer of gray matter on the surface of the cerebral hemisphere that develops from the telencephalon.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0000956"
+      },
+      {
+        "value": "frontal lobe",
+        "description": "Frontal lobe is the anterior-most of five lobes of the cerebral hemisphere. It is bounded by the central sulcus on its posterior border and by the longitudinal cerebral fissure on its medial border.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0016525"
+      },
+      {
+        "value": "hippocampus",
+        "description": "A curved elongated ridge that extends over the floor of the descending horn of each lateral ventricle of the brain and consists of gray matter covered on the ventricular surface with white matter.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0000601"
+      },
+      {
+        "value": "nerve tissue",
+        "description": "Portion of tissue in the nervous system which consists of neurons and glial cells, and may also contain parts of the vasculature.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0003714"
+      },
+      {
+        "value": "dorsolateral prefrontal cortex",
+        "description": "Broadly-defined, consists of the lateral portions of Brodmann areas 9 - 12, of areas 45, 46, and the superior part of area 47.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0009834"
+      },
+      {
+        "value": "anterior cingulate cortex",
+        "description": "That portion of the cingulate cortex which is located within the frontal lobe (the remainder being in the parietal lobe).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0004249"
+      },
+      {
+        "value": "frontal pole",
+        "description": "Component of the frontal lobe. The rostral and caudal boundaries of the frontal pole are the superior frontal gyrus and the rostral division of the middle frontal gyrus respectively (Christine Fennama-Notestine).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002795"
+      },
+      {
+        "value": "parahippocampal gyrus",
+        "description": "A long convolution on the medial surface of the temporal lobe, forming the lower part of the fornicate gyrus, extending from behind the splenium corporis callosi forward along the dentate gyrus of the hippocampus from which it is demarcated by the hippocampal fissure.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0004380"
+      },
+      {
+        "value": "superior temporal gyrus",
+        "description": "Component of the temporal lobe, lateral aspect. The rostral boundary is the rostral extent of the ssuperior temporal sulcus. The caudal boundary is the cauday portion of the superior temporal gyrus (posterior to becoming continuous with the supramarginal gyrus).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002769"
+      },
+      {
+        "value": "inferior frontal gyrus",
+        "description": "Component of the frontal lobe, lateral aspect. The rostral boundary is the first appearance of the inferior frontal sulcus whereas the caudal boundary is the precentral gyrus. The medial and lateral boundaries are the lateral bank of the inferior frontal sulcus and the medial bank of the lateral orbital sulcus and/or the circular insular sulcus respectively (Christein Fennema-Notestine).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002998"
+      },
+      {
+        "value": "cerebellum",
+        "description": "Part of the metencephalon that lies in the posterior cranial fossa behind the brain stem.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002037"
+      },
+      {
+        "value": "occipital visual cortex",
+        "description": "The area of the occipital lobe of the cerebral cortex concerned with vision.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0001857"
+      },
+      {
+        "value": "inferior temporal gyrus",
+        "description": "Component of the temporal lobe, lateral aspect. The rostral boundary is the rostral extent of the inferior temporal sulcus whereas the caudal boundary is designated as the temporo-occipital incisure on the cortical surface.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002751"
+      },
+      {
+        "value": "middle temporal gyrus",
+        "description": "Component of the temporal lobe, lateral aspect. The rostral boundary is the rostral extent of the superior temporal sulcus whereas the caudal boundary is the temporo-occipital incisure on the cortical surface.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002771"
+      },
+      {
+        "value": "posterior cingulate cortex",
+        "description": "Component of the cingulate cortex. The rostral and caudal extent were the caudal anterior and the isthmus divisions of the cingulate cortex respectively.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0022353"
+      },
+      {
+        "value": "temporal pole",
+        "description": "Anterior component of the temporal lobe (rostral boundary) extends caudally to the entorhinal cortex.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002576"
+      },
+      {
+        "value": "precentral gyrus",
+        "description": "Component of the frontal lobe. The appearance and disappearance of the central sulcus is the rostral and caudal boundaries of the precentral gyrus respectively.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002703"
+      },
+      {
+        "value": "superior parietal lobe",
+        "description": "A superficial feature of the parietal lobe that extends from the dorsal surface of the superior parietal lobule across the margin of the parietal lobe into the precuneus.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0026724"
+      },
+      {
+        "value": "prefrontal cortex",
+        "description": "The prefrontal cortex is the anterior part of the frontal lobes of the brain, lying in front of the motor and premotor areas.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0002807"
+      },
+      {
+        "value": "amygdala",
+        "description": "The one of the four basal ganglia in each cerebral hemisphere that is part of the limbic system and consists of an almond-shaped mass of gray matter in the anterior extremity of the temporal lobe.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0001042"
+      },
+      {
+        "value": "caudate nucleus",
+        "description": "Subcortical nucleus of telecephalic origin consisting of an elongated gray mass lying lateral to and bordering the lateral ventricle.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001873"
+      },
+      {
+        "value": "nucleus accumbens",
+        "description": "A region of the brain consisting of a collection of neurons located in the forebrain ventral to the caudate and putamen (caudoputamen in rodent).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001882"
+      },
+      {
+        "value": "putamen",
+        "description": "Subcortical nucleus of telencephalic , which together with the caudate nucleus, forms the striatum.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001874"
+      },
+      {
+        "value": "temporal cortex",
+        "description": "Gray matter of the temporal region of the neocortex, located in the temporal lobe in gyrencephalic animals.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0016538"
+      },
+      {
+        "value": "orbitofrontal cortex",
+        "description": "The region of the cerebral cortex covering the basal surface of the frontal lobes.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0004167"
+      },
+      {
+        "value": "ventrolateral prefrontal cortex",
+        "description": "Is part of the prefrontal cortex, located on the inferior frontal gyrus, bounded superiorly by the inferior frontal sulcus and inferiorly by the lateral sulcus.",
+        "source": "https://en.wikipedia.org/wiki/Ventrolateral_prefrontal_cortex"
+      },
+      {
+        "value": "medial frontal cortex",
+        "description": "Component of the orbtial frontal cortex. The rostral boundary is the first slice where the medial orbital gyrus became visible whereas the caudal boundary is the disappearance of the medial orbital gyrus/gyrus rectus.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0022352"
+      },
+      {
+        "value": "primary motor cortex",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "primary somatosensory cortex",
+        "description": "The part of the cerebral cortex that receives projections from the motor thalamus and which projects to motor neurons in the brainstem and spinal cord.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001384"
+      },
+      {
+        "value": "posteroinferior parietal cortex",
+        "description": "Gray matter of the parietal region of the neocortex, located in the parietal lobe of gyrencephalic animals.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0016530"
+      },
+      {
+        "value": "primary auditory cortex",
+        "description": "The part of the auditory cortex that is located on the superior temporal gyrus in the temporal lobe and receives point-to-point input from the ventral division of the medial geniculate complex.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0034751"
+      },
+      {
+        "value": "posterior superior temporal cortex",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "inferolateral temporal cortex",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "primary visual cortex",
+        "description": "A subdivision of the cytoarchitecturally defined occipital region of cerebral cortex in the human.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002436"
+      },
+      {
+        "value": "amygdaloid complex",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "striatum",
+        "description": "A region of the forebrain consisting of the caudate nucleus, putamen and fundus striati.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002435"
+      },
+      {
+        "value": "mediodorsal nucleus of thalamus",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "cerebellar cortex",
+        "description": "The superficial gray matter of the cerebellum. It consists of three layers, the stratum moleculare, stratum granulosum, and stratum purkinjense.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0000043"
+      },
+      {
+        "value": "serum",
+        "description": "Liquid derived from blood plasma that has clotting factors removed.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001977"
+      },
+      {
+        "value": "plasma",
+        "description": "Plasma is the fluid (noncellular) portion of the circulating blood, as distinguished from the serum that is the fluid portion of the blood obtained by removal of the fibrin clot and blood cells after coagulation.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C13356"
+      },
+      {
+        "value": "splenocyte",
+        "description": "Any leukocyte that is part of a spleen.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cl/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_2000074"
+      },
+      {
+        "value": "blood",
+        "description": "A fluid that is composed of blood plasma and erythrocytes.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0000178"
+      },
+      {
+        "value": "primary tumor",
+        "description": "A primary tumor is the tumor at the initial site of cancer, not where the cancer may have spread or metastasized, called the secondary tumor.",
+        "source": "https://cancergenome.nih.gov/cancersselected/biospeccriteria"
+      },
+      {
+        "value": "Not Applicable",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "meninges",
+        "description": "The three thin layers of tissue that cover and protect the brain and spinal cord.",
+        "source": "https://www.ncbi.nlm.nih.gov/pubmedhealth/PMHT0024758/"
+      },
+      {
+        "value": "forebrain",
+        "description": "The most anterior region the brain including both the telencephalon and diencephalon.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001890"
+      },
+      {
+        "value": "middle frontal gyrus",
+        "description": "Component of the frontal lobe, lateral aspect",
+        "source": "http://purl.obolibrary.org/obo/UBERON_0002702"
+      },
+      {
+
+        "value": "cortical plate",
+        "description": "The outer neural tube region in which post-mitotic neuroblasts migrate along radial glia to form the adult cortical layers",
+        "source": "http://purl.obolibrary.org/obo/UBERON_0005343"
+      },
+      {
+        "value": "VZ/SVZ",
+        "description": "VZ/SVZ (ventricular zone/subventricular zone) are proliferative transient zones situated near the surface of the cerebral lateral ventricles",
+        "source": "Sage Bionetworks"
+      }
+    ]
+  },
+  {
+    "name": "platform",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "HiSeq2500",
+        "description": "Illumina HiSeq 2500",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL16791"
+      },
+      {
+        "value": "HiSeq4000",
+        "description": "Illumina HiSeq 4000",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL20301"
+      },
+      {
+        "value": "NextSeq500",
+        "description": "Illumina NextSeq 500",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL18573"
+      },
+      {
+        "value": "HiSeq2000",
+        "description": "Illumina HiSeq 2000",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL11154"
+      },
+      {
+        "value": "MiSeq",
+        "description": "Illumina MiSeq",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL15520"
+      },
+      {
+        "value": "PsychChip",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Affy5.0",
+        "description": "Affymetrix Genome-Wide Human SNP 5.0 Array",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL6804"
+      },
+      {
+        "value": "Affy6.0",
+        "description": "Affymetrix Genome-Wide Human SNP 6.0 Array",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL6801"
+      },
+      {
+        "value": "PacBioRSII",
+        "description": "PacBio RS II",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL21311"
+      },
+      {
+        "value": "GAIIx",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Illumina_HumanOmni1-Quadv1.0",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Illumina_1M",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Illumina_h650",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Illumina_Omni2pt5M",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Illumina_Omni5M",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Perlegen300Karray",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Agilent44Karray",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "IlluminaWholeGenomeDASL",
+        "description": "Illumina Human Whole-Genome DASL HT",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL13369"
+      },
+      {
+        "value": "IlluminaHumanHap300",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "NanostringnCounter",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "LTQOrbitrapXL",
+        "description": "LTQ Orbitrap XL Hybrid Ion Trap-Orbitrap Mass Spectrometer",
+        "source": "https://www.thermofisher.com/order/catalog/product/IQLAAEGAAPFADBMAOK"
+      },
+      {
+        "value": "IlluminaHumanMethylation450",
+        "description": "Illumina HumanMethylation450 BeadChip ",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL13534"
+      },
+      {
+        "value": "AffymetrixU133AB",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "AffymetrixU133Plus2",
+        "description": "Affymetrix Human Genome U133 Plus 2.0 Array",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL570"
+      },
+      {
+        "value": "confocalImaging",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "IlluminaHumanHT-12_V3_0_R1",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "SequenomMultiplex",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "HiSeqX",
+        "description": "Illumina HiSeq X Platform for whole-genome sequencing",
+        "source": "https://www.illumina.com/systems/sequencing-platforms/hiseq-x.html"
+      },
+      {
+        "value": "Infinium HumanOmniExpressExome",
+        "description": "Infinium HumanOmniExpressExome BeadChip",
+        "source": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL18224"
+      }
+    ]
+  },
+  {
+    "name": "isCellLine",
+    "description": "Boolean flag indicating whether or not sample source is a cell line",
+    "columnType": "BOOLEAN",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": true,
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "isPrimaryCell",
+    "description": "Boolean flag indicating whether or not cellType is primary",
+    "columnType": "BOOLEAN",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": true,
+        "description": "A cell taken directly from a living organism, which is not immortalized",
+        "source": "http://purl.obolibrary.org/obo/BTO_0001413"
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "cellType",
+    "description": "A cell type is a distinct morphological or functional form of cell.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "B-lymphocytes",
+        "description": "A lymphocyte of B lineage with the phenotype CD19-positive and surface immunoglobulin-positive.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000236"
+      },
+      {
+        "value": "iPSC",
+        "description": "Induced pluripotent stem cells (iPS cells or iPSCs) are a type of pluripotent stem cell artificially derived from a non-pluripotent cell.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0004905"
+      },
+      {
+        "value": "iPSC-derived telencephalic organoids",
+        "description": "three-dimensional neural cultures (organoids) derived from induced pluripotent stem cells.",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4519016/"
+      },
+      {
+        "value": "GABAergic neurons",
+        "description": "A neuron that uses GABA as a vesicular neurotransmitter.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/zfa/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FZFA_0009276"
+      },
+      {
+        "value": "monocytes",
+        "description": "Myeloid mononuclear recirculating leukocyte that can act as a precursor of tissue macrophages, osteoclasts and some populations of tissue dendritic cells.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000576"
+      },
+      {
+        "value": "microglia",
+        "description": "The small, non-neural, interstitial cells of mesodermal origin that form part of the supporting structure of the central nervous system.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0000078"
+      },
+      {
+        "value": "macrophages",
+        "description": "A mononuclear phagocyte present in variety of tissues, typically differentiated from monocytes, capable of phagocytosing a variety of extracellular particulate material, including immune complexes, microorganisms, and dead cells.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cl/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000235"
+      },
+      {
+        "value": "astrocytes",
+        "description": "Astrocytes (from 'star' cells) are irregularly shaped with many long processes, including those with end-feet which form the glial (limiting) membrane and directly and indirectly contribute to the blood-brain barrier.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cl/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000127"
+      },
+      {
+        "value": "SH-SY5Y",
+        "description": "Human neuroblastoma clonal subline of the neuroepithelioma cell line SK-N-SH that had been established in 1970 from the bone marrow biopsy of a 4-year-old girl with metastatic neuroblastoma.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0000793"
+      },
+      {
+        "value": "GLUtamatergic neurons",
+        "description": "Have Glutamate receptors, which are synaptic receptors located primarily on the membranes of neuronal cells. Glutamate (the conjugate base of glutamic acid) is abundant in the human body, but particularly in the nervous system and especially prominent in the human brain.",
+        "source": "https://en.wikipedia.org/wiki/Glutamate_receptor"
+      },
+      {
+        "value": "NeuN+",
+        "description": "Is a neuronal nuclear antigen that is commonly used as a biomarker for neurons and NeuN immunoreactivity has been widely used to identify neurons in tissue culture to measure the neuron(positive)/glia(negative) ratio in brain regions.",
+        "source": "https://en.wikipedia.org/wiki/NeuN"
+      },
+      {
+        "value": "NeuN-",
+        "description": "Is a neuronal nuclear antigen that is commonly used as a biomarker for neurons and NeuN immunoreactivity has been widely used to identify neurons in tissue culture to measure the neuron(positive)/glia(negative) ratio in brain regions.",
+        "source": "https://en.wikipedia.org/wiki/NeuN"
+      },
+      {
+        "value": "epithelial",
+        "description": "Somatic cells that cover the surface of the body and line its cavities.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000066"
+      },
+      {
+        "value": "epithelial-like",
+        "description": "In cell morphology, epithelial-like cells are polygonal in shape with more regular dimensions, and grow attached to a substrate in discrete patches.",
+        "source": "https://www.thermofisher.com/us/en/home/references/gibco-cell-culture-basics/cell-morphology.html"
+      },
+      {
+        "value": "fibroblast",
+        "description": "A connective tissue cell which secretes an extracellular matrix rich in collagen and other macromolecules. Flattened and irregular in outline with branching processes; appear fusiform or spindle-shaped.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cl/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000057"
+      },
+      {
+        "value": "round",
+        "description": "A phenotype observation at the level of the cell shape where the cell is round",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cmpo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fcmpo%2FCMPO_0000118"
+      },
+      {
+        "value": "lymphoblast",
+        "description": "Often referred to as a blast cell. Unlike other usages of the suffix -blast a lymphoblast is a further differentiation of a lymphocyte, T- or B-, occasioned by an antigenic stimulus. The lymphoblast usually develops by enlargement of a lymphocyte, active re-entry to the S phase of the cell cycle, mitogenesis and production of much m-RNA and ribosomes.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0000772"
+      },
+      {
+        "value": "polygonal",
+        "description": "A polygonal face is a polygon bounded by a circuit of polygon edges, and includes the flat (plane) region inside the boundary.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/sio/terms?iri=http%3A%2F%2Fsemanticscience.org%2Fresource%2FSIO_000503"
+      },
+      {
+        "value": "CD8+ T-Cells",
+        "description": " Is a T lymphocyte (a type of white blood cell) that kills cancer cells, cells that are infected (particularly with viruses), or cells that are damaged in other ways.",
+        "source": "https://en.wikipedia.org/wiki/Cytotoxic_T_cell"
+      },
+      {
+        "value": "arachnoid",
+        "description": "An arachnoid mater is a delicate membrane that encloses the spinal cord and brain and lies between the pia mater and dura mater.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0001636"
+      },
+      {
+        "value": "meningioma",
+        "description": "A central nervous system cancer tissue that are manifested in the central nervous system and arise from the arachnoid 'cap' cells of the arachnoid villi in the meninges.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_3565"
+      },
+      {
+        "value": "schwannoma",
+        "description": "A neoplasm that arises from SCHWANN CELLS of the cranial, peripheral, and autonomic nerves.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000693"
+      },
+      {
+        "value": "oligodendrocyte",
+        "description": "A class of large neuroglial (macroglial) cells in the central nervous system. Form the insulating myelin sheath of axons in the central nervous system.",
+        "source": "http://purl.obolibrary.org/obo/CL_0000128"
+      },
+      {
+        "value": "schwann",
+        "description": "Schwann cells are a variety of glial cell that keep peripheral nerve fibres (both myelinated and unmyelinated) alive.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBTO_0001220"
+      },
+      {
+        "value": "iPSC-derived neuron",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "monocyte-derived microglia",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "iPSC-derived neuronal progenitor cell",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "CD138+",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "diagnosis",
+    "description": "A diagnosis is the result of a medical investigation to identify a disorder from its signs and symptoms.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Tourette Syndrome",
+        "description": "Neurologic disorder manifested particularly by motor and vocal tics and associated with behavioral abnormalities. ",
+        "source": "http://identifiers.org/omim/137580"
+      },
+      {
+        "value": "Neurofibromatosis 1",
+        "description": "(NF1) - A disease characterized by patches of skin pigmentation (cafe-au-lait spots), Lisch nodules of the iris, tumors in the peripheral nervous system and fibromatous skin tumors. Individuals with the disorder have increased susceptibility to the development of benign and malignant tumors.",
+        "source": ""
+      },
+      {
+        "value": "Neurofibromatosis 2",
+        "description": "(NF2) - Genetic disorder characterized by bilateral vestibular schwannomas (formerly called acoustic neuromas), schwannomas of other cranial and peripheral nerves, meningiomas, and ependymomas. It is inherited in an autosomal dominant fashion with full penetrance.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cco/terms?iri=http%3A%2F%2Fidentifiers.org%2Fomim%2F101000"
+      },
+      {
+        "value": "Bipolar Disorder",
+        "description": "A mood disorder formerly characterised by alternating periods of mania and depression (and in some cases rapid cycling, mixed states, and psychotic symptoms).",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/nbo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNBO_0000258"
+      },
+      {
+        "value": "Alzheimer Disease",
+        "description": "(AD) - Alzheimer disease is a neurodegenerative disorder characterized by progressive dementia, loss of cognitive abilities, and deposition of fibrillar amyloid proteins as intraneuronal neurofibrillary tangles, extracellular amyloid plaques and vascular amyloid deposits.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cco/terms?iri=http%3A%2F%2Fidentifiers.org%2Fomim%2F104300"
+      },
+      {
+        "value": "Schizophrenia",
+        "description": "A severe emotional disorder of psychotic depth characteristically marked by a retreat from reality with delusion formation, HALLUCINATIONS, emotional disharmony, and regressive behavior.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000692"
+      },
+      {
+        "value": "Autism Spectrum Disorder",
+        "description": "Wide continuum of associated cognitive and neurobehavioral disorders, including, but not limited to, three core-defining features: impairments in socialization, impairments in verbal and nonverbal communication, and restricted and repetitive patterns of behaviors.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0003756"
+      },
+      {
+        "value": "Fibrocystic Breast Disease",
+        "description": "breast fibrocystic disease is a benign mammary displasia characterised by breast discomfort and 'lumpiness'.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0003014"
+      },
+      {
+        "value": "Breast Cancer",
+        "description": "(BC) - A common malignancy originating from breast epithelial tissue.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/cco/terms?iri=http%3A%2F%2Fidentifiers.org%2Fomim%2F114480"
+      },
+      {
+        "value": "Colon Cancer",
+        "description": "A colorectal cancer that is located_in the colon.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_219"
+      },
+      {
+        "value": "Lung Cancer",
+        "description": "A respiratory system cancer that is located_in the lung.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_1324"
+      },
+      {
+        "value": "Prostate Cancer",
+        "description": "A male reproductive organ cancer that is located_in the prostate.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_10283"
+      },
+      {
+        "value": "Pancreatic Cancer",
+        "description": "An endocrine gland cancer located_in the pancreas.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_1793"
+      },
+      {
+        "value": "Skin Cancer",
+        "description": "An integumentary system cancer located_in the skin that is the uncontrolled growth of abnormal skin cells.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_4159"
+      },
+      {
+        "value": "Brain Cancer",
+        "description": "A central nervous system cancer that is characterized by the growth of abnormal cells in the tissues of the brain.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_1319"
+      },
+      {
+        "value": "Ovary Cancer",
+        "description": "An ovarian cancer that is derives_from ovarian surface epithelium.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_2152"
+      },
+      {
+        "value": "Affective Disorder",
+        "description": "Change in mood is the main underlying feature of these disorders.",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "Not Applicable",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "isMultiIndividual",
+    "description": "Boolean flag indicating whether or not a file has data for multiple individuals",
+    "columnType": "BOOLEAN",
+    "enumValues": [
+      {
+        "value": true,
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "isMultiSpecimen",
+    "description": "Boolean flag indicating whether or not a file has data for multiple specimens",
+    "columnType": "BOOLEAN",
+    "enumValues": [
+      {
+        "value": true,
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "sex",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "male",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "female",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "species",
+    "description": "The name of a species (typically a taxonomic group) of organism.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "Human",
+        "description": "Homo sapiens with taxonomy ID: 9606 and Genbank common name: human",
+        "source": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606&lvl=3&lin=f&keep=1&srchmode=1&unlock"
+      },
+      {
+        "value": "Mouse",
+        "description": "Mus musculus with taxonomy ID: 10090 and Genbank common name: house mouse",
+        "source": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090&lvl=3&lin=f&keep=1&srchmode=1&unlock"
+      },
+      {
+        "value": "Rat",
+        "description": "Rattus with taxonomy ID: 10114 and inherited blast name: rodents",
+        "source": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10114&lvl=3&lin=f&keep=1&srchmode=1&unlock"
+      },
+      {
+        "value": "Drosophila melanogaster",
+        "description": "Drosophila melanogaster with taxonomy ID: 7227 and Genbank common name: fruit fly",
+        "source": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=7227&lvl=3&p=has_linkout&p=blast_url&p=genome_blast&p=mapview&lin=f&keep=1&srchmode=1&unlock"
+      },
+      {
+        "value": "Rhesus macaque",
+        "description": "Macaca mulatta with taxonomy ID: 9544 and Genbank common name: Rhesus monkey",
+        "source": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9544&lvl=3&p=has_linkout&p=blast_url&p=genome_blast&p=mapview&lin=f&keep=1&srchmode=1&unlock"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/genie.json
+++ b/synapseAnnotations/json_schema/ontology/genie.json
@@ -1,0 +1,91 @@
+[
+  {
+    "name": "fileStage", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "staging", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "release", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "cBioFileFormat", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "clinical", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "CNA", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "fusions", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "center", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "NKI", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "DFCI", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "GRCC", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "JHU", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "MSK", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UHN", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "VICC", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "MDA", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/network.json
+++ b/synapseAnnotations/json_schema/ontology/network.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name" : "networkEdgeType",
+    "description" : "Method used to derive the edge in a network",
+    "columnType" : "STRING",
+    "maximumSize" : 256,
+    "enumValues": [
+       {
+       "value": "protein-protein interaction",
+        "description": "Temporary, non-covalent binding between protein molecules. Protein-protein interactions occur as a result of intermolecular physical forces and spatial complementation between domains or motifs. This interaction can be either homotypic or heterotypic and effect protein structure, conformation, and function.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C18469"
+      },
+      {
+        "value" : "genetic interaction",
+        "description" : "Two genes A and B `genetically interact` when the phenotype generated as the result of variations in both genes (double variant ab) is unexpectedly not just a combination of the phenotypes of the two single variants a and b.",
+        "source" : "http://purl.obolibrary.org/obo/VariO_0237"
+       },
+       {
+         "value": "Gene expression correlation",
+         "description":  "Analyse the correlation patterns among genes across across a variety of experiments, microarray samples etc.",
+         "source" : "http://edamontology.org/operation_3463"
+        }
+    ]
+ }
+]

--- a/synapseAnnotations/json_schema/ontology/neuro.json
+++ b/synapseAnnotations/json_schema/ontology/neuro.json
@@ -1,0 +1,852 @@
+[
+  {
+    "name": "group", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "MSSM", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Yale", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "LIBD", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UCLA", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UIC-UChicago", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Duke", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UNC", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UCSF", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "USC", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "GIS", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "JHU", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Emory", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Columbia-Broad-Rush", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "UFL-Mayo-ISB", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Myers-NIAGADS", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "IU-JAX", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Columbia-SUNY", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Mayo", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "Lilly", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "GSK", 
+        "description": "", 
+        "source": ""
+      }, 
+      { 
+        "value": "Harvard-MIT", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "grant", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "R01AG051556", 
+        "description": "INTERDISCIPLINARY RESEARCH TO UNDERSTAND THE INTERPLAY OF DIABETES, CEREBROVASCULAR DISEASE AND ALZHEIMERS DISEASE", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9005299&icde=26663961&ddparam=&ddvalue=&ddsub=&cr=2&csb=default&cs=ASC"
+      }, 
+      {
+        "value": "U01MH103339", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "U01MH103392", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "U01MH103346", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "U01MH103340", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "U01MH103365", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R01MH094714", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R21MH105881", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R01MH105472", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R21MH102791", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R21MH103877", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "R01MH105898", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "P50MH106934", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "U01AG046152", 
+        "description": "Pathway discovery, validation and compound identification for Alzheimer's Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9336775&icde=36348440&ddparam=&ddvalue=&ddsub=&cr=2&csb=default&cs=ASC&pball="
+      }, 
+      {
+        "value": "U01AG046170", 
+        "description": "Integrative biology approach to complexity of Alzheimer's Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9338117&icde=36348751&ddparam=&ddvalue=&ddsub=&cr=1&csb=default&cs=ASC&pball="
+      }, 
+      {
+        "value": "U01AG046139", 
+        "description": "A system approach to targeting innate immunity in AD", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9336765&icde=36348787&ddparam=&ddvalue=&ddsub=&cr=1&csb=default&cs=ASC&pball="
+      }, 
+      {
+        "value": "U01AG046161", 
+        "description": "Discovery of novel proteomic targets for treatment of Alzheimer's Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9336770&icde=36348585&ddparam=&ddvalue=&ddsub=&cr=2&csb=default&cs=ASC&pball="
+      }, 
+      {
+        "value": "R01AG046174", 
+        "description": "Targeting a novel regulator of brain aging and Alzheimer's Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9321469&icde=36348628&ddparam=&ddvalue=&ddsub=&cr=1&csb=default&cs=ASC&pball="
+      }, 
+      {
+        "value": "R01AG046171", 
+        "description": "Metabolic networks and pathways in Alzheimer's Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=8605398&icde=36348546&ddparam=&ddvalue=&ddsub=&cr=6&csb=default&cs=ASC&pball="
+      },
+      {
+        "value": "U01MH106883", 
+        "description": "BSMN Peter Park-Christopher Walsh", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9056578&icde=31374171"
+      },
+      {
+        "value": "U01MH106874", 
+        "description": "BSMN Nenad Sestan", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9056579&icde=31374208"
+      },
+      {
+        "value": "U01MH106893", 
+        "description": "BSMN Dan Weinberger", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9056580&icde=31374234"
+      },
+      {
+        "value": "U01MH106892", 
+        "description": "BSMN John Moran", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9061833&icde=31374239"
+      },
+      {
+        "value": "U01MH106882", 
+        "description": "BSMN Fred Gage", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9056581&icde=31374248"
+      },
+      {
+        "value": "U01MH106876", 
+        "description": "BSMN Flora Vaccarino", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9061832&icde=31374256"
+      },
+      {
+        "value": "U01MH108898", 
+        "description": "BSMN Joeseph Gleeson", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9147013&icde=31374268"
+      },
+      {
+        "value": "U01MH106891", 
+        "description": "BSMN Scharam Akbarian-Andrew Chess-Christopher Walsh", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9147640&icde=31374287"
+      },
+      {
+        "value": "U01MH106884", 
+        "description": "BSMN Jonathan Pevsner", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9147012&icde=31374293"
+      },
+      {
+        "value": "1RF1AG051504", 
+        "description": "Integrative translational discovery of vascular risk factors in aging and dementia", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9001610&icde=26663490&ddparam=&ddvalue=&ddsub=&cr=19&csb=default&cs=ASC"
+      },
+      {
+        "value": "1RF1AG051556", 
+        "description": "Interdisciplinary research to understand the interplay of diabetes, cerebrovascular disease and Alzheimers Disease", 
+        "source": "https://projectreporter.nih.gov/project_info_description.cfm?aid=9005299&icde=26663961&ddparam=&ddvalue=&ddsub=&cr=2&csb=default&cs=ASC"
+      }
+    ]
+  }, 
+  {
+    "name": "assayTarget", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "H3K9me3", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K4me3", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K4me1", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K27ac", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K36me3", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K27me3", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "H3K9ac", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "REST", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "CTCF", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "input", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "study", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "iPSCAstrocytes", 
+        "description": "The MSSM iPSCAstrocytes study", 
+        "source": "https://www.synapse.org/#!Synapse:syn10344967"
+      },
+      {
+        "value": "TyrobpKO_AppPs1", 
+        "description": "TyrobpKO mice crossed with APP/PS1 tg", 
+        "source": "https://www.synapse.org/#!Synapse:syn10378730"
+      }, 
+      {
+        "value": "CMC", 
+        "description": "CommonMind Consortium", 
+        "source": "https://www.synapse.org/#!Synapse:syn2759792/wiki/69613"
+      }, 
+      {
+        "value": "DiCAD", 
+        "description": "Interdisciplinary Research to Understand the Interplay of Diabetes, Cerebrovascular disease and Alzheimer’s disease", 
+        "source": "https://www.synapse.org/#!Synapse:syn9944859"
+      }, 
+      {
+        "value": "EpiMap", 
+        "description": "Epigenetic Map in neuropsychiatric control tissue", 
+        "source": "https://www.synapse.org/#!Synapse:syn4566010"
+      }, 
+      {
+        "value": "CNON", 
+        "description": "Cultured Neurnal cells derived from Olfactory Neuroepithelium ", 
+        "source": "https://www.synapse.org/#!Synapse:syn4590897"
+      }, 
+      {
+        "value": "MouseHAL", 
+        "description": "Chronic Haloperidol Effects on Gene Expression and Chromatin Accessibility in Mouse Brain", 
+        "source": "https://www.synapse.org/#!Synapse:syn4590850"
+      }, 
+      {
+        "value": "WGBS Pilot", 
+        "description": "Whole Genome Bisulfite Sequencing pilot", 
+        "source": "https://www.synapse.org/#!Synapse:syn4586517"
+      }, 
+      {
+        "value": "lncRNA Pilot", 
+        "description": "long non-coding RNA pilot", 
+        "source": "https://www.synapse.org/#!Synapse:syn4588462"
+      }, 
+      {
+        "value": "BrainGVEX", 
+        "description": "Genetic Variants effect on Brain Gene eXpression", 
+        "source": "https://www.synapse.org/#!Synapse:syn4590909"
+      }, 
+      {
+        "value": "UCLA-ASD", 
+        "description": "A study of samples from the Autism Tissue Program", 
+        "source": "https://www.synapse.org/#!Synapse:syn4587609"
+      }, 
+      {
+        "value": "iPSC", 
+        "description": "Gene regulatory elements and transcriptome in iPSCs and postmortem human cortex ", 
+        "source": "https://www.synapse.org/#!Synapse:syn4590910"
+      }, 
+      {
+        "value": "HumanFC", 
+        "description": "Decoding schizophrenia-From GWAS to functional regulatory variants", 
+        "source": "https://www.synapse.org/#!Synapse:syn5321694"
+      }, 
+      {
+        "value": "EpiGABA", 
+        "description": "GABA Epigenomes in Autism", 
+        "source": "https://www.synapse.org/#!Synapse:syn4588488"
+      }, 
+      {
+        "value": "NHP-Macaque", 
+        "description": "A transcription atlas of the rhesus monkey brain", 
+        "source": ""
+      }, 
+      {
+        "value": "Yale-ASD", 
+        "description": "Transcriptional and Epigenetic Signatures of Human Brain Development and Autism-", 
+        "source": "https://www.synapse.org/#!Synapse:syn4566141"
+      }, 
+      {
+        "value": "BipSeq", 
+        "description": "RNA Sequencing of the limbic system in bipolar disorder", 
+        "source": "https://www.synapse.org/#!Synapse:syn5844980"
+      }, 
+      {
+        "value": "ACT", 
+        "description": "Adult Changes in Thought ", 
+        "source": "https://www.synapse.org/#!Synapse:syn5759376"
+      }, 
+      {
+        "value": "BLSA", 
+        "description": "Baltimore Longitudinal Study on Aging", 
+        "source": "https://www.synapse.org/#!Synapse:syn3606086"
+      }, 
+      {
+        "value": "HBTRC", 
+        "description": "Harvard Brain Tissue Resource Center", 
+        "source": "https://www.synapse.org/#!Synapse:syn3159435"
+      }, 
+      {
+        "value": "MSBB", 
+        "description": "Mount Sinai Brain Bank AD Cohort", 
+        "source": "https://www.synapse.org/#!Synapse:syn3159438"
+      }, 
+      {
+        "value": "ROSMAP", 
+        "description": "Religious Orders Study and Memory and Aging Project", 
+        "source": "https://www.synapse.org/#!Synapse:syn3219045"
+      }, 
+      {
+        "value": "MayoLOADGWAS", 
+        "description": "Mayo Clinic LOAD genome-wide association and brain gene expression studies", 
+        "source": "https://www.synapse.org/#!Synapse:syn2910256"
+      }, 
+      {
+        "value": "MayoeGWAS", 
+        "description": "Gene expression from the Illumina Whole Genome DASL array", 
+        "source": "https://www.synapse.org/#!Synapse:syn3157225"
+      }, 
+      {
+        "value": "MayoPilotRNAseq", 
+        "description": "RNAseq on a subset of MayoEGWAS", 
+        "source": "https://www.synapse.org/#!Synapse:syn3157268"
+      }, 
+      {
+        "value": "IL10_APPmouse", 
+        "description": "IL10 overexpression in APP mouse", 
+        "source": "https://www.synapse.org/#!Synapse:syn3157175"
+      }, 
+      {
+        "value": "Emory_ADRC", 
+        "description": "Emory Alzheimer’s Disease Research Center", 
+        "source": "https://www.synapse.org/#!Synapse:syn3218563"
+      }, 
+      {
+        "value": "TAUAPPms", 
+        "description": "Tau and APP mouse model", 
+        "source": "https://www.synapse.org/#!Synapse:syn3157182"
+      }, 
+      {
+        "value": "RNAseq_SampleSwap", 
+        "description": "RNAseq from sapmples swapped between 3 groups", 
+        "source": "https://www.synapse.org/#!Synapse:syn5550419"
+      }, 
+      {
+        "value": "MayoRNAseq", 
+        "description": "Mayo RNAseq study", 
+        "source": "https://www.synapse.org/#!Synapse:syn5550404"
+      }, 
+      {
+        "value": "BroadMDMi", 
+        "description": "A novel human in vitro microglia-like model", 
+        "source": "https://www.synapse.org/#!Synapse:syn3607404"
+      }, 
+      {
+        "value": "BroadiPSC", 
+        "description": "iPSC derived forebrain neurons", 
+        "source": "https://www.synapse.org/#!Synapse:syn3607401"
+      }, 
+      {
+        "value": "MSDM", 
+        "description": "Mount Sinai Drosophila Melanogaster", 
+        "source": "https://www.synapse.org/#!Synapse:syn4587607"
+      }, 
+      {
+        "value": "OFMM", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "LillyMicroglia", 
+        "description": "Microglia gene profiling in the rTg4510 tauopathy mouse model", 
+        "source": "https://www.synapse.org/#!Synapse:syn5478323"
+      }, 
+      {
+        "value": "UPenn", 
+        "description": "Center for Neurodegenerative Disease Research at the Perelman School of Medicine of the University of Pennsylvania", 
+        "source": "https://www.synapse.org/#!Synapse:syn5477237"
+      }, 
+      {
+        "value": "SY5Y_REST", 
+        "description": "LiCl treated SH-SY5Y cells", 
+        "source": "https://www.synapse.org/#!Synapse:syn5987497"
+      }, 
+      {
+        "value": "MSSMiPSC", 
+        "description": "iPSC derived hiPSC forebrain neurons and NPCs", 
+        "source": "https://www.synapse.org/#!Synapse:syn5986884"
+      }, 
+      {
+        "value": "TyrobpKO", 
+        "description": "Mouse Tyrobp KO model", 
+        "source": "https://www.synapse.org/#!Synapse:syn7123287"
+      }, 
+      {
+        "value": "iPSCMicroglia", 
+        "description": "iPSC derived microglia", 
+        "source": "https://www.synapse.org/#!Synapse:syn7203233"
+      }, 
+      {
+        "value": "BroadAstrom109", 
+        "description": "Primary astrocytes and iPSC derived neurons", 
+        "source": "https://www.synapse.org/#!Synapse:syn7204912"
+      }, 
+      {
+        "value": "Banner", 
+        "description": "Banner Sun Health Research Institute's Brain and Body Donation Program", 
+        "source": "https://www.synapse.org/#!Synapse:syn7170616"
+      }, 
+      {
+        "value": "EmoryDrosophilaTau", 
+        "description": "Emory Drosophila Tau model ", 
+        "source": "https://www.synapse.org/#!Synapse:syn7274101"
+      }, 
+      {
+        "value": "HDAC1-cKOBrain", 
+        "description": "HDAC1 expression in the brain", 
+        "source": "https://www.synapse.org/#!Synapse:syn5987310"
+      }, 
+      {
+        "value": "U1-70_PrimaryCellCulture", 
+        "description": "APP.PS1 and U1-70 transduced neurons", 
+        "source": "https://www.synapse.org/#!Synapse:syn5820226"
+      }, 
+      {
+        "value": "MSMM", 
+        "description": "Mount Sinai Mouse Models", 
+        "source": "https://www.synapse.org/#!Synapse:syn5477220"
+      }, 
+      {
+        "value": "TauD35", 
+        "description": "Mouse tauopathy model", 
+        "source": "https://www.synapse.org/#!Synapse:syn5714308"
+      }, 
+      {
+        "value": "APOE-TR", 
+        "description": "APOE Targeted Replacement", 
+        "source": "https://www.synapse.org/#!Synapse:syn8391648"
+      }, 
+      {
+        "value": "JAX_APPPS1", 
+        "source": "https://www.synapse.org/#!Synapse:syn9850001"
+      }, 
+      {
+        "value": "SY5Y_Emory", 
+        "description": "APP/TAU transduced SY5Y cells", 
+        "source": "https://www.synapse.org/#!Synapse:syn8513284"
+      }, 
+      {
+        "value": "WallOfTargets", 
+        "description": "", 
+        "source": ""
+      },
+      {
+        "value": "CMC_HBCC", 
+        "description": "The CommonMind Consortium Human Brain Collection Core Cohort", 
+        "source": ""
+      },
+      {
+        "value": "ADMC_ADNI1", 
+        "description": "Metabolomics and lipidomics of the AD metabolome as well as imaging from ADNI", 
+        "source": "https://www.synapse.org/#!Synapse:syn5592519"
+      },
+      {
+        "value": "ADMC_ADNI2-GO", 
+        "description": "Clinical, imaging, genetic, and biochemical biomarker characteristics of the entire spectrum of Alzheimer’s disease (AD)", 
+        "source": "https://www.synapse.org/#!Synapse:syn9705278"
+      },
+      {
+        "value": "ADMC_UPenn", 
+        "description": "Metabolomics on AD", 
+        "source": "https://www.synapse.org/#!Synapse:syn9705311"
+      },
+      {
+        "value": "CHDWB", 
+        "description": "Clinical, metabolomic, and gene expression data of controls", 
+        "source": "https://www.synapse.org/#!Synapse:syn8272982"
+      },
+      {
+        "value": "MSBB_ArrayTissuePanel", 
+        "description": "Expression array and coexpression networks on 19 brain regions", 
+        "source": "https://www.synapse.org/#!Synapse:syn3157699"
+      },
+      {
+        "value": "MC-CAA", 
+        "description": "RNAseq data on cerebral amyloid angiopathy (CAA) pathology", 
+        "source": "https://www.synapse.org/#!Synapse:syn9779506"
+      },
+      {
+        "value": "rnaSeqReprocessing", 
+        "description": "Re-aligned reads from the ROSMAP, MSBB, and MayoRNAseq studies", 
+        "source": "https://www.synapse.org/#!Synapse:syn9702085"
+      },
+      {
+        "value": "rnaSeqSampleSwap", 
+        "description": "RNAseq samples sequenced at multiple sites", 
+        "source": "https://www.synapse.org/#!Synapse:syn5550419"
+      },
+      {
+        "value": "SUNYStrokeModel", 
+        "description": "Mouse behavioral assays on stroke and AD models", 
+        "source": "https://www.synapse.org/#!Synapse:syn7181520"
+      },
+      {
+        "value": "TASTPM", 
+        "description": "A double transgenic mouse model", 
+        "source": "https://www.synapse.org/#!Synapse:syn5714307"
+      },
+      {
+        "value": "iPSCAstrocytes", 
+        "description": "iPSC derived astrocytes", 
+        "source": "https://www.synapse.org/#!Synapse:syn10344967"
+      }
+      
+    ]
+  },
+  {
+    "name": "fileSubFormat", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "TranscriptomeSAM", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "SortedByCoordinate", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "hemisphere", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "left", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "right", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "treatmentType", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "haloperidol", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "placebo", 
+        "description": "", 
+        "source": ""
+      },
+      {
+        "value": "clozapine",
+        "description": "A second generation antipsychotic used in the treatment of psychiatric disorders like schizophrenia.",
+        "source": "http://purl.obolibrary.org/obo/CHEBI_3766"
+      }
+    ]
+  },
+  {
+    "name": "modelSystemName", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "TREM2", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "TYROBP", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "AB42", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "CRND8", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "APPPS1", 
+        "description": "", 
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "MAPT-P301K", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "rTg4510", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "APPE693Q", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "APPKM650", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "APPKM670", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "APPKM670-671NL-PSEN1deltaexon9", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "TYROBP_WT", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "TYROBP_WT.KO", 
+        "description": "", 
+        "source": ""
+      }, 
+      {
+        "value": "TYROBP_KO.KO", 
+        "description": "", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "isModelSystem",
+    "description": "",
+    "columnType": "BOOLEAN",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": true,
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "modelSystemStrainNomenclature", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "B6.Cg-Tg(APPswe,PSEN1dE9)85Dbo/Mmjax", 
+        "description": "Double transgenic mice express a chimeric mouse/human amyloid precursor protein (Mo/HuAPP695swe) and a mutant human presenilin 1 (PS1-dE9) both directed to CNS neurons.", 
+        "source": "https://www.jax.org/strain/005864"
+      },
+      {
+        "value": "C57BL/6J", 
+        "description": "C57BL/6 is the most widely used inbred strain. It is commonly used as a general purpose strain and background strain for the generation of congenics carrying both spontaneous and induced mutations.", 
+        "source": "https://www.jax.org/strain/000664"
+      },
+      {
+        "value": "rTg(tauP301L)4510",
+        "description": "The mice express a repressible form of human tau containing the P301L mutation that has been linked with familial frontotemporal dementia.",
+        "source": "http://www.alzforum.org/research-models/rtgtaup301l4510"
+      },
+      {
+        "value":"B6.129P2-Tyrobptm1lll",
+        "description":"Deletion of exons 3 and 4 should result in loss of function of the Tyrobp gene by deleting the transmembrane region and part of the cytoplasmic region.",
+        "source":"https://www.taconic.com/mouse-model/tyrobp-ko-12665"
+      },
+      {
+        "value":"Tg(Camk2a-tTA)1Mmay Tg(tetO-MAPT*P301L)#Kha/J",
+        "description":"These bitransgenic mice have tauP301L expression in the forebrain, and that expression can be greatly reduced by administration of the tetracycline analog, doxycycline.",
+        "source":"https://www.jax.org/strain/024854"
+      },
+      {
+        "value":"Tg(Prnp-MAPT*P301L)JNPL3Hlmc",
+        "description":"The mouse prion protein promoter was used to drive expression of human microtubule-associated protein tau with a P301L substitution. Hemizygous mice mice expressed the protein at levels roughly equivalent to that of endogenous tau.",
+        "source":"http://www.informatics.jax.org/allele/MGI:3604148"
+      },
+      {
+        "value":"B6C3-Tg(APPswe,PSEN1dE9)85Dbo/Mmjax",
+        "description":"Double transgenic mice express a chimeric mouse/human amyloid precursor protein (Mo/HuAPP695swe) and a mutant human presenilin 1 (PS1-dE9) both directed to CNS neurons. ",
+        "source":"https://www.jax.org/strain/004462"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/neurofibromatosis.json
+++ b/synapseAnnotations/json_schema/ontology/neurofibromatosis.json
@@ -1,0 +1,91 @@
+[
+  {
+    "name": "study", 
+    "description": "This key represents a way to divide up research projects within or across consoritia", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Cell Culture", 
+        "description": "NTAP-funded cell culture initiative related data", 
+        "source": "http://www.n-tap.org/initiatives/cell-culture-models/"
+      }, 
+      {
+        "value": "Unsolicited", 
+        "description": "NTAP-funded unsolicited efforts", 
+        "source": "http://www.n-tap.org/initiatives/open-proposal-program/"
+      }, 
+      {
+        "value": "PRO", 
+        "description": "NTAP-funded patient-related outcome program data", 
+        "source": "http://www.n-tap.org/initiatives/patient-reported-outcomes/"
+      }, 
+      {
+        "value": "Francis Collins", 
+        "description": "NTAP-funded Francis Collins scholar program data", 
+        "source": "http://www.n-tap.org/initiatives/collins-scholars/"
+      }, 
+      {
+        "value": "Cutaneous NF", 
+        "description": "Data derived from the CTF-funded cNF efforts", 
+        "source": ""
+      }
+    ]
+  }, 
+  {
+    "name": "nf2Genotype", 
+    "description": "Genotype of NF2 gene, if known", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "-/-", 
+        "description": "Homozygous deletion or mutation of NF2.", 
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "+/-", 
+        "description": "Heterozygous deletion or mutation", 
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "+/+", 
+        "description": "Homozygous wild type", 
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "unknown", 
+        "description": "", 
+        "source": "Sage Bionetworks"
+      }
+    ]
+  }, 
+  {
+    "name": "nf1Genotype", 
+    "description": "Genotype of NF1 gene, if known", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "-/-", 
+        "description": "Homozygous deletion or mutation of NF1.", 
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "+/-", 
+        "description": "Heterozygous deletion or mutation", 
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "+/+", 
+        "description": "Homozygous wildtype", 
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "unknown", 
+        "description": "", 
+        "source": "Sage Bionetworks"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/ngs.json
+++ b/synapseAnnotations/json_schema/ontology/ngs.json
@@ -1,0 +1,231 @@
+[
+  {
+    "name": "runType",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "singleEnd",
+        "description": "A library preparation that results in the creation of a library of 5' ends of DNA.",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "pairedEnd",
+        "description": "A library preparation that results in the creation of a library of the 5' and 3' ends of DNA or cDNA fragments using adaptors and endonucleases. The preparation may or may not include cloning process.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0001852"
+      }
+    ]
+  },
+  {
+    "name": "isStranded",
+    "description": "Whether or not the library is stranded.",
+    "columnType": "BOOLEAN",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": true,
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": false,
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "readPairOrientation",
+    "description": "The relative orientation of the reads in a paired-end protocol",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "inward",
+        "description": "Reads face each other",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "outward",
+        "description": "Reads face away from each other",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "matching",
+        "description": "Reads face the same direction",
+        "source": "Sage Bionetworks"
+      }
+    ]
+  },
+  {
+    "name": "readStrandOrigin",
+    "description": "The strand from which the read originates in a strand-specific protocol",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "forward",
+        "description": "Read 1 (or unpaired read) comes from the forward strand and read 2 (if applicable) comes from the reverse strand; equivalent to Tophat 'fr-secondstrand' type",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "reverse",
+        "description": "read 1 (or unpaired read) comes from the reverse strand and read 2 (if applicable) comes from the forward strand; equivalent to Tophat 'fr-firststrand' type",
+        "source": "Sage Bionetworks"
+      }
+    ]
+  },
+  {
+    "name": "libraryPrep",
+    "description": "The general strategy by which the library was prepared",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "rRNAdepletion",
+        "description": "Total RNA library with ribosomal RNA depleted.",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "polyAselection",
+        "description": "RNA selection by polyA tail capture",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "lncRNAenrichment",
+        "description": "RNA library enriched for lncRNA",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "miRNAenrichment",
+        "description": "RNA library with size selection for microRNAs",
+        "source": "Sage Bionetworks"
+      }
+    ]
+  },
+  {
+    "name": "libraryPreparationMethod",
+    "description": "Method by which library was prepared",
+    "columnType":"STRING",
+    "maximumSize": 256,
+    "enumValues" : [
+      {
+        "value": "10x",
+        "description": "10x Genomics library preparation",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "value": "CEL-seq",
+        "description": "CEL-Seq library preparation",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "value": "Drop-Seq",
+        "description": "Drop-Seq library preparation",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      }
+      ,{
+        "value": "Smart-seq2",
+        "description": "Smart-seq 2 library preparation",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      }
+      ,{
+        "value": "TruSeq",
+        "description": "TruSeq library preparation",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      }
+    ]
+  },
+  {
+    "name": "nucleicAcidSource",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 256,
+    "enumValues": [
+      {
+        "name": "bulk cell",
+        "description": "All cells from bulk sample",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name":"single cell",
+        "description": "Single cell",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "bulk nuclei",
+        "description": "All nuclei from bulk sample",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "single nucleus",
+        "description": "Single nuclei",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name":"mitochondria",
+        "description": "Mitochondria only",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      }
+    ]
+  },
+  {
+    "name": "dissociationMethod",
+    "description": "",
+    "columnType": "STRING",
+    "maximumSize": 256,
+    "enumValues": [
+      {         
+        "name":" 10x_v2", 
+        "description" : "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name":"FACS", 
+        "description" : "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "Fluidigm C1", 
+        "description" : "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "drop-seq", 
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "inDrop", 
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "mouth pipette", 
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "bulk",
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {           
+        "name": "enzymatic",
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "mechanical",
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      },
+      {
+        "name": "none",
+        "description": "",
+        "source": "https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/process/sequencing/library_preparation_process.json"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/sageCommunity.json
+++ b/synapseAnnotations/json_schema/ontology/sageCommunity.json
@@ -1,0 +1,450 @@
+[
+  {
+    "name": "resourceType",
+    "description": "The type of resource being stored and annotated",
+    "columnType": "STRING",
+    "maximumSize" : 250,
+    "enumValues" : [
+      {
+        "value": "experimentalData",
+        "description": "Any file derived from or pertaining to a scientific experiment. experimentalData annotations should be applied, possibly disease-related",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "curatedData",
+        "description": "Any file derived from or pertaining a manually or programatically curated data resource. Examples include: reference sequences, drug information databases, identifier maps",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "analysis",
+        "description": "Any file derived from analysis such that the analysis annotations might apply, possibly disease-related",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "tool",
+        "description": "Any file or link that represents a tool, model, or algorithm; the tool annotations could be applied",
+        "source": "Sage Bionetworks"
+      }
+    ]
+  },
+
+  {
+    "name": "fundingAgency",
+    "description": "The organization providing financial support for generation of this data.",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "CTF",
+        "description": "Childrens' Tumor Foundation",
+        "source": "http://www.ctf.org"
+      },
+      {
+        "value": "NIH-NCI",
+        "description": "National Institutes of Health - National Cancer Institute",
+        "source": "https://www.cancer.gov"
+      },
+      {
+        "value": "NTAP",
+        "description": "Neurofibromatosis Therapeutic Acceleration Program",
+        "source": "http://www.n-tap.org"
+      },
+      {
+        "value": "NIH-NIA",
+        "description": "National Institutes of Health - National Institute of Aging",
+        "source": "https://www.nia.nih.gov"
+      },
+      {
+        "value": "NIH-NIMH",
+        "description": "National Institutes of Health - National Institute of Mental Health",
+        "source": "https://www.nimh.nih.gov"
+      },
+      {
+        "value": "AACR",
+        "description": "American Association for Cancer Research",
+        "source": "http://www.aacr.org"
+      }
+    ]
+  },
+  {
+    "name": "consortium",
+    "description": "The name of the consortium",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "CMC",
+        "description": "CommonMind Consortium",
+        "source": "https://www.synapse.org/cmc"
+      },
+      {
+        "value": "PEC",
+        "description": "PsychENCODE Consortium",
+        "source": "https://www.synapse.org/pec"
+      },
+      {
+        "value": "AMP-AD",
+        "description": "Accelerating Medicines Partnership-Alzheimer's Disease",
+        "source": "https://www.synapse.org/ampad"
+      },
+      {
+        "value": "MODEL-AD",
+        "description": "Model Development and Evaluation for Late Onset AD",
+        "source": "https://www.synapse.org/ampad"
+      },
+      {
+        "value": "M2OVE-AD",
+        "description": "Molecular Mechanisms of the Vascular Etiology of Alzheimer's Disease ",
+        "source": "https://www.synapse.org/ampad"
+      },
+      {
+        "value": "BSMN",
+        "description": "Brain Somatic Mosaicism Network",
+        "source": "https://www.synapse.org/bsmn"
+      },
+      {
+        "value": "CSBC",
+        "description": "Cancer Systems Biology Consortium",
+        "source": "https://csbconsortium.org/"
+      },
+      {
+        "value": "PSON",
+        "description": "Physical Science in Oncology",
+        "source": "https://physics.cancer.gov/"
+      },
+      {
+        "value": "GENIE",
+        "description": "Genomics Evidence Neoplasia Information Exchange",
+        "source": "http://www.aacr.org/Research/Research/Pages/aacr-project-genie.aspx#.WOQS9RIrKF0"
+      },
+      {
+        "value": "Synodos NF1",
+        "description": "Data derived from the CTF-funded NF1 pre-clinical model Synodos project",
+        "source": "https://www.synapse.org/ctf"
+      },
+      {
+        "value": "Synodos NF2",
+        "description": "Data derived from the CTF-funded NF2 Synodos project",
+        "source": "https://www.synapse.org/syndosnf2"
+      },
+      {
+        "value": "Synodos LGG",
+        "description": "Data derived from the CTF-funded NF1 LGG Synodos project",
+        "source": "http://www.synapse.org/nf1lgg"
+      },
+      {
+        "value": "DHART SPORE",
+        "description": "Data from the D-HART SPORE",
+        "source": "http://www.synapse.org/dhart"
+      },
+      {
+        "value": "Not Applicable",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "fileFormat",
+    "description": "Defined format of the data file, typically corresponding to extension, but sometimes indicating more general group of files produced by the same tool or software",
+    "columnType": "STRING",
+    "maximumSize": 250,
+    "enumValues": [
+      {
+        "value": "bash script",
+        "description": "Bash Shell Script",
+        "source": "https://en.wikipedia.org/wiki/Shell_script"
+      },
+      {
+        "value": "bedgraph",
+        "description": "Holds a tab-delimited chromosome /start /end / datavalue dataset. The bedGraph format allows display of continuous-valued data in track format. This display type is useful for probability scores and transcriptome data",
+        "source": "http://edamontology.org/format_3583"
+      },
+      {
+        "value": "idx",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "idat",
+        "description": "Proprietary file format for (raw) BeadArray data used by genomewide profiling platforms from Illumina Inc. This format is output directly from the scanner and stores summary intensities for each probe-type on an array.",
+        "source": "http://edamontology.org/format_3578"
+      },
+      {
+        "value": "bam",
+        "description": "BAM format, the binary, BGZF-formatted compressed version of SAM format for alignment of nucleotide sequences (e.g. sequencing reads) to (a) reference sequence(s)",
+        "source": "http://edamontology.org/format_2572"
+      },
+      {
+        "value": "bai",
+        "description": "BAM indexing format",
+        "source": "http://edamontology.org/format_3327"
+      },
+      {
+        "value": "excel",
+        "description": "Microsoft Excel spreadsheet format",
+        "source": ""
+      },
+      {
+        "value": "powerpoint",
+        "description": "Microsoft Powerpoint slide format",
+        "source": ""
+      },
+      {
+        "value": "tif",
+        "description": "Tagged Image File Format, abbreviated TIFF or TIF, is a computer file format for storing raster graphics images",
+        "source": "https://en.wikipedia.org/wiki/TIFF"
+      },
+      {
+        "value": "png",
+        "description": "PNG is a file format for image compression",
+        "source": "http://edamontology.org/format_3603"
+      },
+      {
+        "value": "doc",
+        "description": "Microsoft Word document format",
+        "source": ""
+      },
+      {
+        "value": "pdf",
+        "description": "Portable Document Format",
+        "source": "http://edamontology.org/format_3508"
+      },
+      {
+        "value": "hdf",
+        "description": "Hierarchical Data Format (HDF) is a set of file formats (HDF4, HDF5) designed to store and organize large amounts of data",
+        "source": "https://en.wikipedia.org/wiki/Hierarchical_Data_Format"
+      },
+      {
+        "value": "fasta",
+        "description": "FASTA format is a text-based format for representing either nucleotide sequences or peptide sequences, in which nucleotides or amino acids are represented using single-letter codes",
+        "source": "https://en.wikipedia.org/wiki/FASTA_format"
+      },
+      {
+        "value": "fastq",
+        "description": "FASTQ format is a text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores. Both the sequence letter and quality score are each encoded with a single ASCII character for brevity",
+        "source": "https://en.wikipedia.org/wiki/FASTQ_format"
+      },
+      {
+        "value": "sam",
+        "description": "Sequence Alignment/Map (SAM) format for alignment of nucleotide sequences (e.g. sequencing reads) to (a) reference sequence(s)",
+        "source": "http://edamontology.org/format_2573"
+      },
+      {
+        "value": "vcf",
+        "description": "Variant Call Format (VCF) for sequence variation (indels, polymorphisms, structural variation)",
+        "source": "http://edamontology.org/format_3016"
+      },
+      {
+        "value": "bcf",
+        "description": "BCF, the binary version of Variant Call Format (VCF) for sequence variation (indels, polymorphisms, structural variation)",
+        "source": "http://edamontology.org/format_3016"
+      },
+      {
+        "value": "maf",
+        "description": "Multiple Alignment Format (MAF) supporting alignments of whole genomes with rearrangements, directions, multiple pieces to the alignment, and so forth",
+        "source": "http://edamontology.org/format_3008"
+      },
+      {
+        "value": "bed",
+        "description": "Browser Extensible Data (BED) format of sequence annotation track, typically to be displayed in a genome browser",
+        "source": "http://edamontology.org/format_3003"
+      },
+      {
+        "value": "chp",
+        "description": "CHP file contains probe set analysis results generated from Affymetrix software",
+        "source": ""
+      },
+      {
+        "value": "cel",
+        "description": "Format of Affymetrix data file of information about (raw) expression levels of the individual probes",
+        "source": "http://edamontology.org/format_1638"
+      },
+      {
+        "value": "sif",
+        "description": "SIF (simple interaction file) Format - a network/pathway format used for instance in cytoscape",
+        "source": "http://edamontology.org/format_3619"
+      },
+      {
+        "value": "tsv",
+        "description": "Tabular data represented as tab-separated values in a text file",
+        "source": "http://edamontology.org/format_3475"
+      },
+      {
+        "value": "csv",
+        "description": "Tabular data represented as comma-separated values in a text file",
+        "source": "http://edamontology.org/format_3752"
+      },
+      {
+        "value": "txt",
+        "description": "Textual format",
+        "source": "http://edamontology.org/format_2330"
+      },
+      {
+        "value": "plink",
+        "description": "Any Plink file format (MAP/PED/BED/BIM/FAM)",
+        "source": "https://www.cog-genomics.org/plink2/formats"
+      },
+      {
+        "value": "bigwig",
+        "description": "bigWig format for large sequence annotation tracks that consist of a value for each sequence position",
+        "source": "http://edamontology.org/format_3006"
+      },
+      {
+        "value": "wiggle",
+        "description": "Wiggle format (WIG) of a sequence annotation track that consists of a value for each sequence position",
+        "source": "http://edamontology.org/format_3005"
+      },
+      {
+        "value": "gct",
+        "description": "Tab-delimited text files of GenePattern that contain a column for each sample, a row for each gene, and an expression value for each gene in each sample",
+        "source": "http://edamontology.org/format_3709"
+      },
+      {
+        "value": "bgzip",
+        "description": "Blocked GNU Zip format",
+        "source": "http://edamontology.org/format_3615"
+      },
+      {
+        "value": "seg",
+        "description": "SEG file (segmented data; .seg or .cbs) is a tab-delimited text file that lists loci and associated numeric values",
+        "source": "https://software.broadinstitute.org/software/igv/SEG"
+      },
+      {
+        "value": "html",
+        "description": "HTML format",
+        "source": "http://edamontology.org/format_2331"
+      },
+      {
+        "value": "md",
+        "description": "Markdown (MD) is a lightweight markup language with plain text formatting syntax",
+        "source": "https://en.wikipedia.org/wiki/Markdown"
+      },
+      {
+        "value": "flagstat",
+        "description": "Output of samtools flagstat tool",
+        "source": ""
+      },
+      {
+        "value": "gtf",
+        "description": "Gene transfer format (GTF) is a file format used to hold information about gene structure",
+        "source": "https://en.wikipedia.org/wiki/Gene_transfer_format"
+      },
+      {
+        "value": "raw",
+        "description": "Proprietary file format for mass spectrometry data from Thermo Scientific",
+        "source": "http://edamontology.org/format_3712"
+      },
+      {
+        "value": "msf",
+        "description": "Proprietary mass-spectrometry format of Thermo Scientific's ProteomeDiscoverer software",
+        "source": "http://edamontology.org/format_3702"
+      },
+      {
+        "value": "rmd",
+        "description": "markdown document specific to r analyses",
+        "source": "http://rmarkdown.rstudio.com/developer_document_templates.html"
+      },
+      {
+        "value": "bed narrowPeak",
+        "description": "This format is used to provide called peaks of signal enrichment based on pooled, normalized (interpreted) data. It is a BED6+4 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format12"
+      },
+      {
+        "value": "bed broadPeak",
+        "description": "This format is used to provide called regions of signal enrichment based on pooled, normalized (interpreted) data. It is a BED 6+3 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format13"
+      },
+      {
+        "value": "bed gappedPeak",
+        "description": "This format is used to provide called regions of signal enrichment based on pooled, normalized (interpreted) data where the regions may be spliced or incorporate gaps in the genomic sequence. It is a BED12+3 format.",
+        "source": "http://genome.ucsc.edu/FAQ/FAQformat.html#format14"
+      },
+      {
+        "value": "avi",
+        "description": "AVI files can contain both audio and video data in a file container that allows synchronous audio-with-video playback.",
+        "source":"https://en.wikipedia.org/wiki/Audio_Video_Interleave"
+      },
+      {
+        "value": "pzfx",
+        "description": "A PZFX file is a Prism project created by GraphPad Prism, a scientific application used to analyze and graph data. It contains project data including graphs and layouts, notes, and tables.",
+        "source":"https://fileinfo.com/extension/pzfx"
+      },
+      {
+        "value": "fig",
+        "description": "Line drawing saved in the Xfig format; stored as a vector image that may include lines, shapes, arcs, splines, arrows, and text objects; may also include images, colors, and patterns.",
+        "source":"https://fileinfo.com/extension/fig"
+      },
+      {
+        "value": "xml",
+        "description": "eXtensible Markup Language (XML) format.",
+        "source":"http://edamontology.org/format_2332"
+      },
+      {  "value": "tar",
+         "description": "tape archive",
+         "source": "https://en.wikipedia.org/wiki/Tar_(computing)"
+      },
+      {
+        "value": "R script",
+        "description": "R Script",
+        "source": "Sage Bionetworks"
+      }, 
+      {
+        "value": "abf",
+        "description": "The Axon™ Binary File format (ABF) was created for the storage of binary experimental data.",
+        "source": "https://mdc.custhelp.com/euf/assets/content/ABFHelp.pdf"
+      },
+      {
+        "value": "bpm",
+        "description": "A beaded pool manifest. Describe the SNP or probe content on a BeadChip or in an assay pool.",
+        "source": "https://support.illumina.com/datafiles.html"
+      },
+      {
+        "value": "dat",
+        "description": "Format of Affymetrix data file of raw image data.",
+        "source": "http://edamontology.org/format_1637"
+      },
+      {
+        "value": "jpg",
+        "description": "Joint Picture Group file format for lossy graphics file.",
+        "source": "http://edamontology.org/format_3579"
+      },
+      {
+        "value": "locs",
+        "description": "Illumina iScan bead location file.",
+        "source": "https://support.illumina.com/content/dam/illumina-support/documents/documentation/system_documentation/iscan/iscan-system-guide-11313539-01.pdf"
+      },
+      {
+
+        "value": "Sentrix descriptor file",
+        "description": "A BeadScan specific file needed to perform scan setting checks for different array formats and assay type.",
+        "source": "https://support.illumina.com/content/dam/illumina-support/documents/myillumina/dd0aff11-2664-481b-a8ce-26831a907cae/beadscan_3.0_software_addendum.pdf"
+      },
+      {
+        "value": "Python script",
+        "description": "Python is an interpreted, object-oriented, high-level programming language with dynamic semantics.",
+        "source": "https://www.python.org/doc/essays/blurb/"
+      },
+      {
+        "value": "sav",
+        "description": "The SPSS Statistics File Format is a proprietary binary format, developed and maintained as the native format for the SPSS statistical software application.",
+        "source": "https://www.loc.gov/preservation/digital/formats/fdd/fdd000469.shtml"
+      },
+      {
+        "value": "xml",
+        "description": "eXtensible Markup Language (XML) format.",
+        "source": "http://edamontology.org/format_2332"
+      },
+      {
+        "value": "sdf",
+        "description": "SDF is one of a family of chemical-data file formats developed by MDL Information Systems; it is intended especially for structural information.",
+        "source": "http://edamontology.org/format_3814"
+      },
+      {
+        "value": "RData",
+        "description": "The RData format (usually with extension .rdata or .rda) is a format designed for use with R, a system for statistical computation and related graphics, for storing a complete R workspace or selected 'objects' from a workspace in a form that can be loaded back by R.",
+        "source": "https://www.loc.gov/preservation/digital/formats/fdd/fdd000470.shtml"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/tool.json
+++ b/synapseAnnotations/json_schema/ontology/tool.json
@@ -1,0 +1,347 @@
+[
+  {
+    "name": "softwareType", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "script",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "packageLibrary",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "packageBinary",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "container",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "graphical user interface",
+        "description":"A Graphical user interface is a type of software interface that allows users to interact with electronic devices using images rather than text commands. A GUI represents the information and actions available to a user through graphical icons and visual indicators such as secondary notation, as opposed to text-based interfaces, typed command labels or text navigation.",
+        "source":"https://www.ebi.ac.uk/ols/ontologies/swo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fswo%2Finterface%2FSWO_9000052"
+      },
+      {
+        "value": "web user interface",
+        "description":"A Web User interface is a Graphical User Interface which is loaded and run via a Web browser rather than within the user's operating system.",
+        "source":"https://www.ebi.ac.uk/ols/ontologies/swo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fswo%2Finterface%2FSWO_5000002"
+      },
+      {
+        "value" : "web application",
+        "description" : "A piece of software that operates primarily through a stand-alone web interaface.",
+        "source" : "Sage Bionetworks"
+      }
+    ]
+  },
+  {
+    "name": "softwareLanguage", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "R",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Python",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Matlab",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Shell",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Java",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "softwareRepository", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Synapse",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "GitHub",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "GitLab",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "BitBucket",
+        "description": "",
+        "source": ""
+      }, 
+      {
+        "value": "CRAN",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "BioConductor",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Biocontainers",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "DockerHub",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Quay",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Dockstore",
+        "description": "",
+        "source": ""
+      }     
+    ]
+  },
+  {
+    "name": "softwareRepositoryType", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "fileStore",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "sourceCode",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "packageManager",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "containerRegistry",
+        "description": "",
+        "source": ""
+      }, 
+      {
+        "value": "containerToolRegistry",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "inputDataType", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "genomicVariants",
+        "description": "Genomic alterations, including single nucleotide polymorphisms, short indels and structural variants, in a genome sequence.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Foperation_3227"
+      },
+      {
+        "value": "metabolomics",
+        "description": "The systematic study of metabolites, the chemical processes they are involved, and the chemical fingerprints of specific cellular processes in a whole cell, tissue, organ or organism.",
+        "source": "http://edamontology.org/topic_3172"
+      },
+      {
+        "value": "image",
+        "description": "Biological or biomedical data that has been rendered into an image.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fdata_2968"
+      },
+      {
+        "value": "geneExpression",
+        "description": "The analysis of levels and patterns of synthesis of gene products (proteins and functional RNA) including interpretation in functional terms of gene expression data.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0203"
+      },
+      {
+        "value": "isoformExpression",
+        "description": "Expression of protien isoforms formed from alternative splicings or other post-translational modifications of a single gene through RNA splicing mechanisms.",
+        "source": "https://en.wikipedia.org/wiki/Protein_isoform"
+      },
+      {
+        "value": "proteomics",
+        "description": "Protein and peptide identification, especially in the study of whole proteomes of organisms.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0121"
+      },
+      {
+        "value": "kinomics",
+        "description": "Kinomics is the study of protein kinases and protein kinase signaling.",
+        "source": "http://www.kinomecore.com/what-is-kinomics/"
+      },
+      {
+        "value": "drugScreen",
+        "description": "Information on drug sensitivity and molecular markers of drug response",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531057/"
+      },
+      {
+        "value": "cellularPhysiology",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "chromatinActivity",
+        "description": "Chromatin activity that allow access of condensed genomic DNA and potentially control gene expression.",
+        "source": "https://en.wikipedia.org/wiki/Chromatin_remodeling"
+
+      },
+      {
+        "value": "Network",
+        "description": "An interconnected system of things or people.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C61377"
+      },
+      {
+        "value": "functional screen",
+        "description": "",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "gene list",
+        "description": "A data set of the names or identifiers of genes that are the outcome of an analysis or have been put together for the purpose of an analysis.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0000118"
+
+      },
+      {
+        "value": "ontology",
+        "description": "An ontology of biological or bioinformatics concepts and relations, a controlled vocabulary, structured glossary etc.",
+        "source": "http://edamontology.org/data_0582"
+      },
+      {
+        "value": "surveyData",
+        "description": "A data set that contains the outcome of a survey.",
+        "source": "http://purl.obolibrary.org/obo/OMIABIS_0000060"
+      },
+      {
+        "value": "SMILES",
+        "description": "Small molecule is an organic compound with a low molecular weight (<800 Da) which is used to screen against a biological target, e.g. protein, nucleic acid, cell or organism to test its ability to bind it and bring about a change in activity.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C54684"
+      }
+    ]
+  },
+  {
+    "name": "outputDataType", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "genomicVariants",
+        "description": "Genomic alterations, including single nucleotide polymorphisms, short indels and structural variants, in a genome sequence.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Foperation_3227"
+      },
+      {
+        "value": "metabolomics",
+        "description": "The systematic study of metabolites, the chemical processes they are involved, and the chemical fingerprints of specific cellular processes in a whole cell, tissue, organ or organism.",
+        "source": "http://edamontology.org/topic_3172"
+      },
+      {
+        "value": "image",
+        "description": "Biological or biomedical data that has been rendered into an image.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fdata_2968"
+      },
+      {
+        "value": "geneExpression",
+        "description": "The analysis of levels and patterns of synthesis of gene products (proteins and functional RNA) including interpretation in functional terms of gene expression data.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0203"
+      },
+      {
+        "value": "isoformExpression",
+        "description": "Expression of protien isoforms formed from alternative splicings or other post-translational modifications of a single gene through RNA splicing mechanisms.",
+        "source": "https://en.wikipedia.org/wiki/Protein_isoform"
+      },
+      {
+        "value": "proteomics",
+        "description": "Protein and peptide identification, especially in the study of whole proteomes of organisms.",
+        "source": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Ftopic_0121"
+      },
+      {
+        "value": "kinomics",
+        "description": "Kinomics is the study of protein kinases and protein kinase signaling.",
+        "source": "http://www.kinomecore.com/what-is-kinomics/"
+      },
+      {
+        "value": "drugScreen",
+        "description": "Information on drug sensitivity and molecular markers of drug response",
+        "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531057/"
+      },
+      {
+        "value": "cellularPhysiology",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "chromatinActivity",
+        "description": "Chromatin activity that allow access of condensed genomic DNA and potentially control gene expression.",
+        "source": "https://en.wikipedia.org/wiki/Chromatin_remodeling"
+      },
+      {
+        "value": "surveyData",
+        "description": "A data set that contains the outcome of a survey.",
+        "source": "http://purl.obolibrary.org/obo/OMIABIS_0000060"
+      },
+      {
+        "value": "Network",
+        "description": "An interconnected system of things or people.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C61377"
+      },
+      {
+        "value": "gene list",
+        "description": "A data set of the names or identifiers of genes that are the outcome of an analysis or have been put together for the purpose of an analysis.",
+        "source": "http://purl.obolibrary.org/obo/OBI_0000118"
+      },
+      {
+        "value": "imputed drug response",
+        "description": "Predicted response to a drug",
+        "source": "Sage Bionetworks"
+      },
+      {
+        "value": "ontology",
+        "description": "An ontology of biological or bioinformatics concepts and relations, a controlled vocabulary, structured glossary etc.",
+        "source": "http://edamontology.org/data_0582"
+      },
+      {
+        "value": "small molecule",
+        "description": "Small molecule is an organic compound with a low molecular weight (<800 Da) which is used to screen against a biological target, e.g. protein, nucleic acid, cell or organism to test its ability to bind it and bring about a change in activity.",
+        "source": "http://www.bioassayontology.org/bao#BAO_0000176"
+      }
+    ]
+  }
+]

--- a/synapseAnnotations/json_schema/ontology/toolExtended.json
+++ b/synapseAnnotations/json_schema/ontology/toolExtended.json
@@ -1,0 +1,99 @@
+[
+  {
+    "name": "packageBinaryPlatform", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Windows",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "OSX",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Linux",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "containerPlatform", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Docker",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Singularity",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "workflowPlatform", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Nextflow",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Galaxy",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Snakemake",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Rufus",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "CWL",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "WDL",
+        "description": "",
+        "source": ""
+      }
+    ]
+  },
+  {
+    "name": "containerToolPlatform", 
+    "description": "", 
+    "columnType": "STRING", 
+    "maximumSize": 250, 
+    "enumValues": [
+      {
+        "value": "Docker-CWL",
+        "description": "",
+        "source": ""
+      },
+      {
+        "value": "Docker-WDL",
+        "description": "",
+        "source": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
As part of #351/#375 this creates an `ontology/` folder within `json_schema/`. As a first pass I've just copied every annotation that has multiple options in `enumValues` to the folder. 