### PR TITLE
add resourcetype = report

### DIFF
--- a/synapseAnnotations/data/sageCommunity.json
+++ b/synapseAnnotations/data/sageCommunity.json
@@ -24,6 +24,11 @@
               "value": "tool",
               "description": "Any file or link that represents a tool, model, or algorithm; the tool annotations could be applied",
               "source": "Sage Bionetworks"
+          },
+          {
+              "value": "report",
+              "description": "a document assembled by an author for the purpose of providing information for the audience. A report is the output of a documenting process and has the objective to be consumed by a specific audience. Topic of the report is on something that has completed. A report is not a single figure. Examples of reports are journal article, patent application, grant progress report, case report (not patient record).",
+              "source": "http://purl.obolibrary.org/obo/IAO_0000088"
           }
          ]
   },


### PR DESCRIPTION
I have lots of "report" files to annotate. This used to be an annotation but is gone now (was under dataType, or dataSubtype?). Would be a helpful annotation for the purposes of filtering out human readable data (powerpoints, docs, pdfs). My only concern is having a clear definition that separates this from "analysis" - hopefully this is enough for that distinction: "A report is not a single figure."