### PR TITLE
Add clinical as a dataType

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -503,6 +503,11 @@
         "value": "network",
         "description":"An interconnected system of things or people.",
         "source":"http://purl.obolibrary.org/obo/NCIT_C61377"
+      },
+      {
+        "value": "clinical",
+        "description":"Data obtained through patient examination or treatment.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C15783"
       }
     ]
   },


### PR DESCRIPTION
This adds `"clinical"` as a data type. Though we haven't fully resolved the dataType question in #421, in conversation with @ychae we realized that `"clinical"` is already being used frequently as a dataType and should be reflected in our annotations. This is also consistent with GDC's data types, and I've made sure to use the same definition [they use](https://github.com/NCI-GDC/gdcdictionary/blob/edd332190a8503b84f02fc532e72dcd8fda04370/gdcdictionary/schemas/clinical.yaml#L11-L12) in case we do more fully adopt their model.