### PR TITLE
Add "whole brain" as a tissue

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -865,6 +865,11 @@
         "value": "unspecified",
         "description": "Unspecified tissue or tissues from an organ.",
         "source": "Sage Bionetworks"
+      },
+      {
+        "value": "whole brain",
+        "description": "Brain tissue not limited to a specific region.",
+        "source": "Sage Bionetworks"
       }
     ]
   },


### PR DESCRIPTION
As discussed in the meeting today. I did not find an existing ontology term, and left the description fairly broad. I didn't want to restrict it to _actually_ the entire brain, because we have samples that are from one hemisphere, and I think "whole brain" is still functionally the correct value even though it's technically not the whole brain.