### PR TITLE
Add ELISA as assay and immunoassay as dataType

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -241,6 +241,11 @@
         "value": "RPPA",
         "description": "Reverse phase protein array (RPPA) is a an assay that measures multiple protein expression levels in a large number of biological samples simultaneously using high quality antibodies",
         "source": "http://www.bioassayontology.org/bao#BAO_0010030"
+      },
+      {
+        "value": "ELISA",
+        "description": "A highly sensitive technique for detecting and measuring antigens or antibodies in a solution; the solution is run over a surface to which immobilized antibodies specific to the substance have been attached, and if the substance is present, it will bind to the antibody layer, and its presence is verified and visualized with an application of antibodies that have been tagged in some way.",
+        "source": "http://purl.obolibrary.org/obo/NCIT_C16553"
       }
     ]
   },
@@ -508,6 +513,11 @@
         "value": "clinical",
         "description":"Data obtained through patient examination or treatment.",
         "source":"http://purl.obolibrary.org/obo/NCIT_C15783"
+      },
+      {
+        "value": "immunoassay",
+        "description": "Laboratory test involving interaction of antigens with specific antibodies.",
+        "source":"http://purl.obolibrary.org/obo/NCIT_C16723"
       }
     ]
   },


### PR DESCRIPTION
I've used "immunoassay" (an exact synonym) rather than "Immunology Test" (the preferred term) because it appears that "immunoassay" is already in use in AMP-AD. However if we'd prefer to switch to the preferred term I'm happy to update.