### PR TITLE
Add electrophysiology as dataType

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -575,6 +575,11 @@
         "value": "immunoassay",
         "description": "Laboratory test involving interaction of antigens with specific antibodies.",
         "source":"http://purl.obolibrary.org/obo/NCIT_C16723"
+      },
+      {
+        "value": "electrophysiology",
+        "description": "Data generated from an electrophysiology assay.",
+        "source": "http://purl.obolibrary.org/obo/ERO_0000564"
       }
     ]
   },


### PR DESCRIPTION
This value was already used in the SUNYStrokeModel study in AMP-AD but was never added to the annotations dictionary.