### PR TITLE
Remove duplicate tissue annotations

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -648,24 +648,9 @@
     "maximumSize": 250,
     "enumValues": [
       {
-        "value": "medial orbital frontal cortex",
-        "description": "Component of the orbtial frontal cortex.",
-        "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0022352"
-      },
-      {
-        "value": "medial prefrontal cortex",
-        "description": "",
-        "source": "Sage Bionetworks"
-      },
-      {
         "value": "medial dorsal nucleus of thalamus",
         "description": "A large nucleus in the thalamus. It receives inputs from the Pre-Frontal Cortex and the Limbic System and in turn relays them to the Pre-Frontal Association Cortex. ",
         "source": "http://purl.obolibrary.org/obo/UBERON_0002739"
-      },
-      {
-        "value": "inferior temporal cortex",
-        "description": "",
-        "source": "Sage Bionetworks"
       },
       {
         "value": "posterior inferior parietal cortex",
@@ -916,11 +901,6 @@
         "value": "medial prefrontal cortex",
         "description": "The medial prefrontal cortex (mPFC) is composed of granular cortical areas (medial areas 9 and 10) and agranular regions (areas 24, 25, and 32)",
         "source": "https://en.wikipedia.org/wiki/Prefrontal_cortex#Subdivisions"
-      },
-      {
-        "value": "medial dorsal nucleus of thalamus",
-        "description": "The medial dorsal nucleus (or dorsomedial nucleus of thalamus) is a large nucleus in the thalamus.",
-        "source": "http://www.ebi.ac.uk/ols/ontologies/UBERON/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0002739"
       },
       {
         "value": "inferior temporal cortex",


### PR DESCRIPTION
There are some duplicate values within the tissue annotation. I have removed the duplicates; all the terms are still present.

* [medial orbital frontal cortex](https://github.com/Sage-Bionetworks/synapseAnnotations/blob/f796edd7fcf4bfd9293155123c2d65d826df016c/synapseAnnotations/data/experimentalData.json#L876)
* [medial prefrontal cortex](https://github.com/Sage-Bionetworks/synapseAnnotations/blob/f796edd7fcf4bfd9293155123c2d65d826df016c/synapseAnnotations/data/experimentalData.json#L881)
* [inferior temporal cortex](https://github.com/Sage-Bionetworks/synapseAnnotations/blob/f796edd7fcf4bfd9293155123c2d65d826df016c/synapseAnnotations/data/experimentalData.json#L891)
* [medial dorsal nucleus of thalamus](https://github.com/Sage-Bionetworks/synapseAnnotations/blob/f796edd7fcf4bfd9293155123c2d65d826df016c/synapseAnnotations/data/experimentalData.json#L626)