### PR TITLE
Fix test for duplicate values

### DIFF
--- a/tests/integration/test_json.py
+++ b/tests/integration/test_json.py
@@ -12,14 +12,16 @@ def setup_module(module):
     test_file = os.path.abspath(__file__)
     test_dir = os.path.split(test_file)[0]
     module.json_files = map(lambda x: os.path.abspath(x),
-                            glob.glob("%s/../../*.json" % test_dir))
+                            glob.glob("%s/../../synapseAnnotations/data/*.json" % test_dir))
 
 
 def test_duplicate_values_within_key():
     for json_file in json_files:
-        with file(json_file) as f:
+        with open(json_file) as f:
             d = json.load(f)
-            for k, v in d.iteritems():
+            for i in d:
+                k = i['name']
+                v = [x.get('value') for x in i.get('enumValues') or []]
                 value_count = set([x for x in v if v.count(x) > 1])
                 if value_count:
                     raise ValueError(


### PR DESCRIPTION
* Fixes test so that it correctly understands the a) structure and b) location of our json data
* Updates to work with python 3.6 (which is the default on travis)

Note that it will only show an error for the first duplicate it finds. I think this was how the original test was written too, but we can update it if we want to show all duplicates at once.

This should probably fail travis checks since there are currently duplicate values until #480 and #483 are merged. See also #482.

Review on the pythonic-ness of the code is welcome, it's been a while since I wrote any python...