### PR TITLE
Lint all json files in the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: python
 # command to run tests
 install: pip install -r requirements.txt
 script:
-  - jsonlint $(find . -name "*.json")
+  - find . -name \*.json  | xargs -I {} jsonlint -q {}
   - nosetests


### PR DESCRIPTION
jsonlint can't lint multiple files at once, so this has only been linting the first json file in the repo, not all of them.