### PR TITLE
add type of proeomics assay

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -325,6 +325,11 @@
         "value": "Genotyping",
         "description": "The determination of the DNA sequence of an individual.",
         "source": "http://purl.obolibrary.org/obo/NCIT_C45447"
+      },
+      {
+      	"value": "TMT",
+      	"description":"A high-throughput multiplexed proteomics technique.", 
+      	"source":"https://www.ebi.ac.uk/ols/ontologies/ero/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FERO_0002175"
       }
     ]
   },

--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -334,7 +334,7 @@
       {
       	"value": "label free MS",
       	"description":"A mass spectrometry assay that allows for measurement for endogenous targets in live cell assays, and eliminates the need for tags, dyes, or specialized reagents or engineered cells.", 
-      	"source":"https://www.ebi.ac.uk/ols/ontologies/ero/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FERO_0000708"
+      	"source":"http://purl.obolibrary.org/obo/ERO_0000708"
       }
     ]
   },

--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -330,6 +330,11 @@
       	"value": "TMT",
       	"description":"A high-throughput multiplexed proteomics technique.", 
       	"source":"https://www.ebi.ac.uk/ols/ontologies/ero/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FERO_0002175"
+      }, 
+      {
+      	"value": "label free MS",
+      	"description":"A mass spectrometry assay that allows for measurement for endogenous targets in live cell assays, and eliminates the need for tags, dyes, or specialized reagents or engineered cells.", 
+      	"source":"https://www.ebi.ac.uk/ols/ontologies/ero/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FERO_0000708"
       }
     ]
   },

--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -329,7 +329,7 @@
       {
       	"value": "TMT",
       	"description":"A high-throughput multiplexed proteomics technique.", 
-      	"source":"https://www.ebi.ac.uk/ols/ontologies/ero/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FERO_0002175"
+      	"source":"http://purl.obolibrary.org/obo/ERO_0002175"
       }, 
       {
       	"value": "label free MS",

--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -327,12 +327,12 @@
         "source": "http://purl.obolibrary.org/obo/NCIT_C45447"
       },
       {
-      	"value": "TMT",
-      	"description":"A high-throughput multiplexed proteomics technique.", 
+      	"value": "TMT quantitation",
+      	"description":"An isobaric labeling technique that uses tags containing four regions with the same total molecular weights and structure, so that during chromatographic or electrophoretic separation and in single MS mode, molecules labelled with different tags are indistinguishable.", 
       	"source":"http://purl.obolibrary.org/obo/ERO_0002175"
       }, 
       {
-      	"value": "label free MS",
+      	"value": "label free mass spectrometry",
       	"description":"A mass spectrometry assay that allows for measurement for endogenous targets in live cell assays, and eliminates the need for tags, dyes, or specialized reagents or engineered cells.", 
       	"source":"http://purl.obolibrary.org/obo/ERO_0000708"
       }


### PR DESCRIPTION
If `dataType = proteomics` then it makes sense for an acceptable `assay` value to be a subtype of proteomics. In this case - TMT.