### PR TITLE
Add individualID description

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -1055,7 +1055,7 @@
   },
    {
     "name": "individualID",
-    "description": "",
+    "description": "Identifying string linked to the individual or animal being studied",
     "columnType": "STRING",
     "maximumSize": 250,
     "enumValues": []


### PR DESCRIPTION
The "individualID" key in the experimentalData module did not have a definition, so I gave it one based on the definition of "specimenID" that Kelsey suggested.