### PR TITLE
Add head of caudate nucleus

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -881,6 +881,11 @@
         "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001873"
       },
       {
+        "value": "Head of caudate nucleus",
+        "description": "",
+        "source": "http://purl.obolibrary.org/obo/FMA_61852"
+      },
+      {
         "value": "nucleus accumbens",
         "description": "A region of the brain consisting of a collection of neurons located in the forebrain ventral to the caudate and putamen (caudoputamen in rodent).",
         "source": "https://www.ebi.ac.uk/ols/ontologies/uberon/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001882"


### PR DESCRIPTION
Add "Head of caudate nucleus" to tissue key. This was proposed by a collaborator; we already have "caudate nucleus" but their tissue is more specific. "Head of caudate nucleus" should be used if the tissue sample was specific to that part of the caudate nucleus; "caudate nucleus" should be used otherwise.