### PR TITLE
Fixed typo in assay key

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -39,7 +39,7 @@
       },
       {
         "value": "open field test",
-        "desription": "A test utilizing an enclosure consisting of a single area bordered by clear or opaque walls, used to measure movement, exploratory behavior, etc of an experimental subject.",
+        "description": "A test utilizing an enclosure consisting of a single area bordered by clear or opaque walls, used to measure movement, exploratory behavior, etc of an experimental subject.",
         "source": "http://purl.obolibrary.org/obo/MMO_0000258"
       },
       {


### PR DESCRIPTION
The word "description" was misspelled as "desription" in the "open field test" value under the "assay" key.