### PR TITLE
Update source for orbitrap fusion

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -1133,8 +1133,8 @@
      },
       {
        "value": "OrbiTrap Fusion",
-       "description": "Thermo Scientific™ Orbitrap Fusion™ Tribrid™ Mass Spectrometer.",
-       "source": "https://www.thermofisher.com/order/catalog/product/IQLAAEGAAPFADBMBCX."
+       "description": "Thermo Scientific Orbitrap Fusion",
+       "source": "http://purl.obolibrary.org/obo/MS_1002416"
       },
       {
        "value": "NanostringnCounter_MouseADPanel",


### PR DESCRIPTION
Leaving the capitalization as-is, even though the new source writes it "Orbitrap"