### PR TITLE
Source update

### DIFF
--- a/synapseAnnotations/data/sageCommunity.json
+++ b/synapseAnnotations/data/sageCommunity.json
@@ -90,22 +90,22 @@
       {
         "value": "AMP-AD",
         "description": "Accelerating Medicines Partnership-Alzheimer's Disease",
-        "source": "https://www.synapse.org/ampad"
+        "source": "https://adknowledgeportal.synapse.org/"
       },
       {
         "value": "MODEL-AD",
         "description": "Model Development and Evaluation for Late Onset AD",
-        "source": "https://www.synapse.org/ampad"
+        "source": "https://adknowledgeportal.synapse.org/"
       },
       {
         "value": "M2OVE-AD",
         "description": "Molecular Mechanisms of the Vascular Etiology of Alzheimer's Disease ",
-        "source": "https://www.synapse.org/ampad"
+        "source": "https://adknowledgeportal.synapse.org/"
       },
       {
         "value": "Resilience-AD",
         "description": "Interdisciplinary Research to Understand the Complex Biology of Resilience to Alzheimer's Disease Risk",
-        "source": "https://www.synapse.org/ampad"
+        "source": "https://adknowledgeportal.synapse.org/"
       },
       {
         "value": "BSMN",


### PR DESCRIPTION
Update of source for AMP-AD/M2OVE-AD/MODEL-AD/Resillience-AD to point to the portal instead of Synapse