### PR TITLE
add two tissue terms

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -1123,7 +1123,7 @@
       },
       {
         "value":"insular cortex",
-        "description":"",
+        "description":"insular cortex",
         "source":"http://purl.obolibrary.org/obo/UBERON_0034891"
       }
     ]

--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -1115,6 +1115,16 @@
         "value":"olfactory neuroepithelium",
         "description": "Composed of receptor and supporting cells and olfactory glands of Bowman, located in the superior part of the nasal cavities.",
         "source": "https://www.medilexicon.com/dictionary/60061"
+      },
+      {
+        "value":"medial ganglionic eminence",
+        "description":"A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the neocortex; however, hippocampal neurons, thalamus, septum and olfactory bulb neurons are also partly derived from the MGE.",
+        "source":"http://purl.obolibrary.org/obo/UBERON_0004024"
+      },
+      {
+        "value":"insular cortex",
+        "description":"",
+        "source":"http://purl.obolibrary.org/obo/UBERON_0034891"
       }
     ]
   },


### PR DESCRIPTION
I added two terms by request from PEC researchers. The term "insular cortex" does not have a definition but its parent does. Can we still accept this case?