### PR TITLE
Add script to update table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.Rhistory
+.RData
+.Rproj.user

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ The steps to create a release are as follows:
 
 Generally, you will next want to update the [Synapse table](https://www.synapse.org/#!Synapse:syn10242922) that describes the annotations and powers the [AnnotationUI](https://shinypro.synapse.org/users/nsanati/annotationUI/):
 
-1. Clone the [annotator](https://github.com/Sage-Bionetworks/annotator/) repository locally (e.g. `git clone git@github.com:Sage-Bionetworks/annotator.git`).
-1. From within your local copy of the repository, install annotator (`python setup.py install`).
-1. Run the command `annotator json2table`.
+1. Run the script `update_annotations_table.R`
 
 Additional information about the release process can be found in [issue 392](https://github.com/Sage-Bionetworks/synapseAnnotations/issues/392)

--- a/update_annotations_table.R
+++ b/update_annotations_table.R
@@ -45,10 +45,15 @@ unnest_module <- function(x) {
       keep_empty = TRUE
     ) %>%
     rename(
+      ## Rename columns. This works with our current JSON data, but the
+      ## numbering of columns could change if we change the underlying data
+      ## structure, so pay attention here.
       description = `description...2`,
       valueDescription = `description...6`,
       source = `source...7`
     ) %>%
+    ## Drop source column for keys because a) it's not in the synapse table
+    ## schema and b) very few keys have a source
     select(-`source...10`)
 }
 

--- a/update_annotations_table.R
+++ b/update_annotations_table.R
@@ -1,0 +1,73 @@
+################################################
+####  Update the Synapse Annotations table  ####
+################################################
+
+library("jsonlite")
+library("tidyverse")
+library("reticulate")
+library("glue")
+library("httr")
+library("here")
+
+## Log in to synapse
+synapse <- import("synapseclient")
+syn <- synapse$Synapse()
+syn$login()
+
+## Get release version
+release <- GET("https://api.github.com/repos/Sage-Bionetworks/synapseAnnotations/releases")
+body <- content(release)
+release_version <- body[[1]]$tag_name
+
+## JSON files
+files <- list.files(
+  here("synapseAnnotations", "data"),
+  full.names = TRUE
+)
+files <- files[grepl("\\.json$", files)] # no directories
+names(files) <- tools::file_path_sans_ext(basename(files))
+
+## Ensure `value` column gets converted to character, otherwise `unnest()`
+## complains about incompatible types
+value_to_chr <- function(x) {
+  if(is.null(x$value)) {
+    return(NULL)
+  }
+  mutate(x, value = as.character(value))
+}
+
+## Unnest the enumerated values for each key
+unnest_module <- function(x) {
+  x %>%
+    unnest(cols = "enumValues", names_repair = "universal") %>%
+    rename(
+      description = `description...2`,
+      valueDescription = `description...6`,
+      source = `source...7`
+    ) %>%
+    select(-`source...10`)
+}
+
+## Load in json data
+definitions <- files %>%
+  imap_dfr(~ mutate(fromJSON(.x), module = .y)) %>%
+  mutate(enumValues = map(enumValues, ~ value_to_chr(.x))) %>%
+  unnest_module() %>%
+  mutate(source = coalesce(source, Source)) %>%
+  select(-Source) %>%
+  rename(key = name)
+
+## Delete old table rows
+annots_table <- "syn10242922"
+current <- syn$tableQuery(glue("SELECT * FROM {annots_table}"))
+syn$delete(current) # delete current rows
+
+## Update annotations on the table
+table_obj <- syn$get(annots_table)
+syn$setAnnotations(table_obj, py_dict("annotationReleaseVersion", release_version))
+
+## Update table rows
+temp <- tempfile()
+write_csv(definitions, temp, na = "")
+new <- synapse$Table(annots_table, temp)
+syn$store(new)

--- a/update_annotations_table.R
+++ b/update_annotations_table.R
@@ -39,7 +39,11 @@ value_to_chr <- function(x) {
 ## Unnest the enumerated values for each key
 unnest_module <- function(x) {
   x %>%
-    unnest(cols = "enumValues", names_repair = "universal") %>%
+    unnest(
+      cols = "enumValues",
+      names_repair = "universal",
+      keep_empty = TRUE
+    ) %>%
     rename(
       description = `description...2`,
       valueDescription = `description...6`,

--- a/update_annotations_table.R
+++ b/update_annotations_table.R
@@ -80,3 +80,6 @@ temp <- tempfile()
 write_csv(definitions, temp, na = "")
 new <- synapse$Table(annots_table, temp)
 syn$store(new)
+
+## Query to force table index to rebuild
+syn$tableQuery(glue("SELECT ROW_ID FROM {annots_table} LIMIT 1"))


### PR DESCRIPTION
The code in annotator that updates the table of synapse annotations has been broken for a while and doesn't seem like it's going to be actively maintained. I wrote a script to update the table, thinking it might be useful to keep that within this repo where we can continue to maintain it. 

The table looks ok to me, but something seems to be broken now in the annotationUI shiny app. I've opened a Jira ticket to request access to view the logs; if there's something in this script that is causing the issue I'll fix it.