### PR TITLE
Retype chromatin amount

### DIFF
--- a/synapseAnnotations/data/immunoAssays.json
+++ b/synapseAnnotations/data/immunoAssays.json
@@ -10,7 +10,8 @@
   {
     "name": "antibodyAmount",
     "description": "Amount of antibody used for an assay",
-    "columnType": "INTEGER",
+    "columnType": "STRING",
+    "maximumSize": 250,
     "enumValues": []
   },
   {
@@ -24,7 +25,8 @@
   {
     "name": "chromatinAmount",
     "description": "Amount of chromatin used for an assay",
-    "columnType": "INTEGER",
+    "columnType": "STRING",
+    "maximumSize": 250,
     "enumValues": []
   },
   {

--- a/synapseAnnotations/data/immunoAssays.json
+++ b/synapseAnnotations/data/immunoAssays.json
@@ -10,8 +10,7 @@
   {
     "name": "antibodyAmount",
     "description": "Amount of antibody used for an assay",
-    "columnType": "STRING",
-    "maximumSize": 250,
+    "columnType": "DOUBLE",
     "enumValues": []
   },
   {
@@ -25,8 +24,7 @@
   {
     "name": "chromatinAmount",
     "description": "Amount of chromatin used for an assay",
-    "columnType": "STRING",
-    "maximumSize": 250,
+    "columnType": "DOUBLE",
     "enumValues": []
   },
   {


### PR DESCRIPTION
I looked at EpiMap CHIPSeq data and the chromatinAmount column is a decimal.  I had it typed as an integer.  I saw by looking at other annotations modules that decimal numbers are type as STRING, so I changed the typing from INTEGER to STRING.