### PR TITLE
Add boolean flag for isPostMortem on specimens

### DIFF
--- a/synapseAnnotations/data/experimentalData.json
+++ b/synapseAnnotations/data/experimentalData.json
@@ -1754,6 +1754,11 @@
     "columnType": "BOOLEAN"
   },
   {
+    "name": "isPostMortem",
+    "description": "Boolean flag indicating whether the sample was taken postmortem",
+    "columnType": "BOOLEAN"
+  },
+  {
     "name": "specimenIdSource",
     "description": "",
     "columnType": "STRING",


### PR DESCRIPTION
One use case is for iPSC where there can be a samplingAge (not currently a value in synapseAnnotations), but there needs to be an indication of whether the sample was taken post-mortem.