### PR TITLE
Update definition of differential expression to be more inclusive

### DIFF
--- a/synapseAnnotations/data/analysis.json
+++ b/synapseAnnotations/data/analysis.json
@@ -408,7 +408,7 @@
       },
       {
         "value": "differential expression",
-        "description": "Genes or isoforms that are differentially expressed between two conditions.",
+        "description": "Increased or decreased expression between two conditions.",
         "source": "http://uri.neuinfo.org/nif/nifstd/nlx_qual_100810"
       },
       {


### PR DESCRIPTION
One use case is for differential expression for chromatin activity, which was being excluded by the original definition. The source did not change because the language for this newer definition is in the source.