### PR TITLE
gitignore credentials.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Rproj.user
+credentials.json


### PR DESCRIPTION
example_schema_usage.py downloads credentials to the directory where it's run, which would make it easy to accidentally commit it to the repo. Adding credentials.json to the .gitignore should make that less likely to happen by accident.