### PR TITLE
Add documentation of the important scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,13 @@ Sage Bionetworks derived standards for annotating content in Synapse. This provi
 
 # Annotation definitions
 
-This repository contains schemas that define the things we want to annotate as well as the controlled values that may be used. You can think of these as 'columns' of a table, each with a limited set of values that can occur in each column.
+This repository contains schemas that define the things we want to annotate as well as the controlled values that may be used. 
 
-Our schema definitions are stored here in [Synapse Table Schema](http://docs.synapse.org/articles/tables.html) format. A schema is a list of [`Column Model`s](http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/ColumnModel.html) in JSON format. Using this format allows us to use them in a straightforward manner with other features of Synapse, including [file views](http://docs.synapse.org/articles/fileviews.html) and [tables](http://docs.synapse.org/articles/tables.html).
-
-Column types are required, and the valid types can be found [here](http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/ColumnType.html).
+Our schema definitions are stored here as a csv file, which can be converted into JSON-LD, or JSON Schema for validation.
 
 # Organization
 
-All schema definitions can be found in the [synapseAnnotations/data/](synapseAnnotations/data/) folder. There are three high level schemas: [experimental data](synapseAnnotations/data/experimentalData.json), [tool](synapseAnnotations/data/tool.json), and [analysis](synapseAnnotations/data/analysis.json).
-
-Schemas for specific communities and consortia are also defined, such as for the [neurodegenerative diseases consortiums](synapseAnnotations/data/neuro.json), [cancer consortiums](synapseAnnotations/data/cancer.json), and specific group such as (but not limited to) [Project GENIE](synapseAnnotations/data/genie.json).
+All schema definitions can be found in the [synapseAnnotations/](synapseAnnotations/) folder as `sage_controlled_vocabulary.csv`.
 
 # Development
 
@@ -72,6 +68,6 @@ The steps to create a release are as follows:
 
 Generally, you will next want to update the [Synapse table](https://www.synapse.org/#!Synapse:syn10242922) that describes the annotations and powers the [AnnotationUI](https://shinypro.synapse.org/users/nsanati/annotationUI/):
 
-1. Run the script `update_annotations_table.R`
+1. ~~Run the script `update_annotations_table.R`~~ TODO: update this to work with new CSV format.
 
 Additional information about the release process can be found in [issue 392](https://github.com/Sage-Bionetworks/synapseAnnotations/issues/392)

--- a/synapseAnnotations/README.md
+++ b/synapseAnnotations/README.md
@@ -1,0 +1,30 @@
+# Synapse Annotations data models and scripts
+
+This folder contains data and scripts to manage our annotations data models.
+
+## Install necessary packages
+
+```
+pip install -r requirements.txt
+```
+
+## Convert previous annotations to current format
+
+The `sage_annotations_2_csv_schema.py` script converts the previous annotations
+format to the CSV file `sage_controlled_vocabulary_schema.csv`. It operates on
+data files in `data/original-json` and should not need to be run again, but is
+here for posterity. 
+
+Going forward, changes should be made to the
+`sage_controlled_vocabulary_schema.csv` file directly.
+
+## Convert CSV to JSON-LD
+
+Run `python sage_schema.py` to convert `sage_controlled_vocabulary_schema.csv`
+to JSON-LD. `example_schema.py` is basically the same, but for the example CSV
+in the `schemas/` subfolder.
+
+## Generate a manifest
+
+Run `python example_schema_usage.py`. Requires access to a Google API
+credentials file stored on Synapse.


### PR DESCRIPTION
Adds documentation of the important files within the `synapseAnnotations/` subfolder. @milen-sage, there are many other scripts that I don't know the purpose of, I know you're planning to refactor some of this in the next week so I didn't go too far in trying to figure them out. One thing I did find confusing is that there's a `schemas/` subfolder, but both `sage_controlled_vocabulary_schema.csv` and `sage_schema.jsonld` are in the the `synapseAnnotations/` folder rather than in this subfolder. Should they be moved?