### PR TITLE
IndividualIdSource-Vaccarino

### DIFF
--- a/terms/experimentalData/individualIdSource.json
+++ b/terms/experimentalData/individualIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.individualIdSource-0.0.1",
+    "$id": "sage.annotations-experimentalData.individualIdSource-0.0.2",
     "description": "Database or repository to which individual ID maps",
     "anyOf": [
         {

--- a/terms/experimentalData/individualIdSource.json
+++ b/terms/experimentalData/individualIdSource.json
@@ -119,6 +119,11 @@
             "source": ""
         },
         {
+            "const": "Vaccarino",
+            "description": "Vaccarino Lab, Yale School of Medicine",
+            "source": "https://medicine.yale.edu/lab/vaccarino/"
+        },
+        {
             "const": "Yale",
             "description": "Yale School of Medicine",
             "source": "https://medicine.yale.edu/"


### PR DESCRIPTION
Added the Vaccarino Lab to individualIdSource. Schema was compiled using ajv compile -s and is valid.