### PR TITLE
Add control and no cognitive impairment diagnosis

### DIFF
--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -135,7 +135,7 @@
         },
         {
             "const": "no cognitive impairment",
-            "description": "No known mental and/or intellectual function.",
+            "description": "No known mental and/or intellectual dysfunction.",
             "source": "Sage Bionetworks"
         },
         {

--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -142,6 +142,11 @@
             "const": "control",
             "description": "An individual used as a standard of comparison.",
             "source": "Sage Bionetworks"
+        },
+        {
+            "const": "pathological aging",
+            "description": "A form of cerebral amyloidosis in older people, with widespread extracellular amyloid-beta (Aβ) senile plaque deposits in the setting of limited neurofibrillary tau pathology.",
+            "source": "https://doi.org/10.1186/alzrt254"
         }
     ]
 }

--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.diagnosis-0.0.1",
+    "$id": "sage.annotations-experimentalData.diagnosis-0.0.2",
     "description": "A diagnosis is the result of a medical investigation to identify a disorder from its signs and symptoms.",
     "anyOf": [
         {
@@ -132,6 +132,16 @@
             "const": "mild cognitive impairment",
             "description": "Diminished or impaired mental and/or intellectual function.",
             "source": "http://purl.obolibrary.org/obo/OMIT_0027843"
+        },
+        {
+            "const": "no cognitive impairment",
+            "description": "No known mental and/or intellectual function.",
+            "source": "Sage Bionetworks"
+        },
+        {
+            "const": "control",
+            "description": "An individual used as a standard of comparison.",
+            "source": "Sage Bionetworks"
         }
     ]
 }


### PR DESCRIPTION
Add no cognitive impairment and control to diagnosis. This one is a bit tricky since 'control' isn't technically a diagnosis. However, we have data contributors who are using this to designate control versus non-control patients.

@cw-dvr8, no cognitive impairment is in the AD annotations table so that's one you don't need to add yourself.