### PR TITLE
Make failedQC a proper boolean

### DIFF
--- a/terms/experimentalData/failedQC.json
+++ b/terms/experimentalData/failedQC.json
@@ -2,21 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "sage.annotations-experimentalData.failedQC-0.0.1",
     "description": "Boolean flag indicating whether the sample or data failed QC checks",
-    "anyOf": [
-        {
-            "const": true,
-            "description": "",
-            "source": {
-
-            }
-        },
-        {
-            "const": false,
-            "description": "",
-            "source": {
-
-            }
-        }
-    ]
+    "type": "boolean"
 }
 

--- a/terms/experimentalData/failedQC.json
+++ b/terms/experimentalData/failedQC.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.failedQC-0.0.1",
+    "$id": "sage.annotations-experimentalData.failedQC-0.0.2",
     "description": "Boolean flag indicating whether the sample or data failed QC checks",
     "type": "boolean"
 }


### PR DESCRIPTION
This brings it in line with other boolean annotations, e.g. `isCellLine`