### PR TITLE
Add message when registering schemas

### DIFF
--- a/register-schemas.R
+++ b/register-schemas.R
@@ -21,6 +21,7 @@ create_body <- function(file) {
 }
 
 register_schema <- function(file) {
+  message(glue("Registering {basename(file)}"))
   synRestPOST(
     uri = "/schema/type/create/async/start",
     body = create_body(file)


### PR DESCRIPTION
Makes it easier to tell which schema is causing the problem if registration fails