### PR TITLE
Set up GitHub Actions to validate schemas

### DIFF
--- a/.github/workflows/check-schemas.yaml
+++ b/.github/workflows/check-schemas.yaml
@@ -1,0 +1,37 @@
+on: [push]
+
+env:
+  AJV_CLI_VERSION: 4.0.1
+  NPM_CONFIG_PREFIX: "~/.npm-global"
+
+jobs:
+  check-schemas:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Add .npm-global to PATH
+        run: echo "${NPM_CONFIG_PREFIX}/bin" >> $GITHUB_PATH
+
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Install ajv-cli
+        run: |
+          npm install -g ajv-cli@${AJV_CLI_VERSION}
+
+      - name: Compile mini-schemas
+        run: |
+          ajv compile -s "terms/*/*.json" --strict=false
+
+      - name: Check for non-ascii characters
+        run: |
+          if grep -R -P -l "[^\x00-\x7F]" ./terms/; then
+            exit 1
+          else
+            exit 0
+          fi

--- a/.github/workflows/check-schemas.yaml
+++ b/.github/workflows/check-schemas.yaml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 env:
   AJV_CLI_VERSION: 4.0.1


### PR DESCRIPTION
This adds a GitHub Actions workflow to check that the mini-schemas in `terms/` are 1) valid JSON Schema (using ajv-cli), and 2) contain only ASCII characters, as non-ASCII characters can cause some issues when registering schemas.

There are some other checks I'd like to add going forward, but they're a little more complicated, so I thought I'd start with this since it's useful and not too complicated.