### PR TITLE
Use absolute paths in schema $id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ examples, but the general format for a new term should be like this:
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "anyOf": [
     {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that are valid JSON Schema, such as the following:
 ```
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.1",
     "description": "Identifying string linked to a particular sample or specimen",
     "type": "string"
 }

--- a/schemas/testschema.json
+++ b/schemas/testschema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id":"sage.annotations-testschema.json-0.0.2",
+  "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-testschema.json-0.0.2",
   "properties": {
     "resourceType": {
       "$ref": "sage.annotations-sageCommunity.resourceType-0.0.1"

--- a/schemas/testschema.json
+++ b/schemas/testschema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-testschema.json-0.0.2",
+  "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-testschema.json-0.0.3",
   "properties": {
     "resourceType": {
       "$ref": "sage.annotations-sageCommunity.resourceType-0.0.1"

--- a/term-templates/template-boolean.json
+++ b/term-templates/template-boolean.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "boolean"
 }

--- a/term-templates/template-enum.json
+++ b/term-templates/template-enum.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "anyOf": [
     {

--- a/term-templates/template-number.json
+++ b/term-templates/template-number.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "number"
 }

--- a/term-templates/template-string.json
+++ b/term-templates/template-string.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "string",
   "minLength": 1,

--- a/terms/analysis/alignmentMethod.json
+++ b/terms/analysis/alignmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.alignmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.alignmentMethod-0.0.1",
     "description": "DNA or RNA sequence alignment method",
     "anyOf": [
         {

--- a/terms/analysis/alignmentMethod.json
+++ b/terms/analysis/alignmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.alignmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.alignmentMethod-0.0.2",
     "description": "DNA or RNA sequence alignment method",
     "anyOf": [
         {

--- a/terms/analysis/analysisType.json
+++ b/terms/analysis/analysisType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.analysisType-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.analysisType-0.0.3",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/analysisType.json
+++ b/terms/analysis/analysisType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.analysisType-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.analysisType-0.0.4",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/assemblyMethod.json
+++ b/terms/analysis/assemblyMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.assemblyMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.assemblyMethod-0.0.2",
     "description": "Algorithm used to build a reference genome from short read sequencing data.",
     "anyOf": [
         {

--- a/terms/analysis/assemblyMethod.json
+++ b/terms/analysis/assemblyMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.assemblyMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.assemblyMethod-0.0.1",
     "description": "Algorithm used to build a reference genome from short read sequencing data.",
     "anyOf": [
         {

--- a/terms/analysis/batchEffectCorrectionMethod.json
+++ b/terms/analysis/batchEffectCorrectionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.batchEffectCorrectionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.batchEffectCorrectionMethod-0.0.1",
     "description": "Methods for identifying or correcting potential confounding variables in regression analyses.",
     "anyOf": [
         {

--- a/terms/analysis/batchEffectCorrectionMethod.json
+++ b/terms/analysis/batchEffectCorrectionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.batchEffectCorrectionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.batchEffectCorrectionMethod-0.0.2",
     "description": "Methods for identifying or correcting potential confounding variables in regression analyses.",
     "anyOf": [
         {

--- a/terms/analysis/clusteringMethod.json
+++ b/terms/analysis/clusteringMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.clusteringMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.clusteringMethod-0.0.1",
     "description": "A method to identify groups of similar variables based on their data distribution.",
     "anyOf": [
         {

--- a/terms/analysis/clusteringMethod.json
+++ b/terms/analysis/clusteringMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.clusteringMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.clusteringMethod-0.0.2",
     "description": "A method to identify groups of similar variables based on their data distribution.",
     "anyOf": [
         {

--- a/terms/analysis/differentialExpressionMethod.json
+++ b/terms/analysis/differentialExpressionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.differentialExpressionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.differentialExpressionMethod-0.0.1",
     "description": "Method used to test for differentially expressed genes or isoforms.",
     "anyOf": [
         {

--- a/terms/analysis/differentialExpressionMethod.json
+++ b/terms/analysis/differentialExpressionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.differentialExpressionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.differentialExpressionMethod-0.0.2",
     "description": "Method used to test for differentially expressed genes or isoforms.",
     "anyOf": [
         {

--- a/terms/analysis/enrichmentMethod.json
+++ b/terms/analysis/enrichmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.enrichmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.enrichmentMethod-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/enrichmentMethod.json
+++ b/terms/analysis/enrichmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.enrichmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.enrichmentMethod-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/multipleTestingAdjustmentMethod.json
+++ b/terms/analysis/multipleTestingAdjustmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.2",
     "description": "Method used to control either family wise error rate, false discovery rate, or other measures of burden of false positives and false negatives when performing multiple statistical tests.",
     "anyOf": [
         {

--- a/terms/analysis/multipleTestingAdjustmentMethod.json
+++ b/terms/analysis/multipleTestingAdjustmentMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.1",
     "description": "Method used to control either family wise error rate, false discovery rate, or other measures of burden of false positives and false negatives when performing multiple statistical tests.",
     "anyOf": [
         {

--- a/terms/analysis/peakCallingMethod.json
+++ b/terms/analysis/peakCallingMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.peakCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.peakCallingMethod-0.0.2",
     "description": "The algorithm used to identify protein-binding regions in a genome sequence from the data generated from a ChIP-sequencing or ChIP-chip experiment.",
     "anyOf": [
         {

--- a/terms/analysis/peakCallingMethod.json
+++ b/terms/analysis/peakCallingMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.peakCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.peakCallingMethod-0.0.1",
     "description": "The algorithm used to identify protein-binding regions in a genome sequence from the data generated from a ChIP-sequencing or ChIP-chip experiment.",
     "anyOf": [
         {

--- a/terms/analysis/somaticMutationCallingMethod.json
+++ b/terms/analysis/somaticMutationCallingMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.somaticMutationCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.somaticMutationCallingMethod-0.0.2",
     "description": "Algorithm to call somatic mutations.",
     "anyOf": [
         {

--- a/terms/analysis/somaticMutationCallingMethod.json
+++ b/terms/analysis/somaticMutationCallingMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.somaticMutationCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.somaticMutationCallingMethod-0.0.1",
     "description": "Algorithm to call somatic mutations.",
     "anyOf": [
         {

--- a/terms/analysis/statisticalNetworkReconstructionMethod.json
+++ b/terms/analysis/statisticalNetworkReconstructionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/statisticalNetworkReconstructionMethod.json
+++ b/terms/analysis/statisticalNetworkReconstructionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/analysis/supervisedLearningMethod.json
+++ b/terms/analysis/supervisedLearningMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.supervisedLearningMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.supervisedLearningMethod-0.0.1",
     "description": "An algorithm to fit a model to make predictions of future outcomes based past data.",
     "anyOf": [
         {

--- a/terms/analysis/supervisedLearningMethod.json
+++ b/terms/analysis/supervisedLearningMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.supervisedLearningMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.supervisedLearningMethod-0.0.2",
     "description": "An algorithm to fit a model to make predictions of future outcomes based past data.",
     "anyOf": [
         {

--- a/terms/analysis/transcriptQuantificationMethod.json
+++ b/terms/analysis/transcriptQuantificationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.transcriptQuantificationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.transcriptQuantificationMethod-0.0.1",
     "description": "Method for quantifying abundance of transcript expression.",
     "anyOf": [
         {

--- a/terms/analysis/transcriptQuantificationMethod.json
+++ b/terms/analysis/transcriptQuantificationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.transcriptQuantificationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.transcriptQuantificationMethod-0.0.2",
     "description": "Method for quantifying abundance of transcript expression.",
     "anyOf": [
         {

--- a/terms/analysis/validationMethod.json
+++ b/terms/analysis/validationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.validationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.validationMethod-0.0.1",
     "description": "Method to test targeted sequence level hypothesis.",
     "anyOf": [
         {

--- a/terms/analysis/validationMethod.json
+++ b/terms/analysis/validationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.validationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.validationMethod-0.0.2",
     "description": "Method to test targeted sequence level hypothesis.",
     "anyOf": [
         {

--- a/terms/analysis/visualizationMethod.json
+++ b/terms/analysis/visualizationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.visualizationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.visualizationMethod-0.0.2",
     "description": "The format in which data is visually displayed.",
     "anyOf": [
         {

--- a/terms/analysis/visualizationMethod.json
+++ b/terms/analysis/visualizationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.visualizationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.visualizationMethod-0.0.1",
     "description": "The format in which data is visually displayed.",
     "anyOf": [
         {

--- a/terms/array/channel.json
+++ b/terms/array/channel.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-array.channel-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-array.channel-0.0.2",
     "description": "Fluorescent color labeling for an array",
     "anyOf": [
         {

--- a/terms/array/channel.json
+++ b/terms/array/channel.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-array.channel-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-array.channel-0.0.1",
     "description": "Fluorescent color labeling for an array",
     "anyOf": [
         {

--- a/terms/cancer/cellSubType.json
+++ b/terms/cancer/cellSubType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.cellSubType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.cellSubType-0.0.1",
     "description": "This term is to be used when cell type is not specific enough, such as certain classes of T cells",
     "type": "string"
 }

--- a/terms/cancer/cellSubType.json
+++ b/terms/cancer/cellSubType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.cellSubType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.cellSubType-0.0.2",
     "description": "This term is to be used when cell type is not specific enough, such as certain classes of T cells",
     "type": "string"
 }

--- a/terms/cancer/experimentalCondition.json
+++ b/terms/cancer/experimentalCondition.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.experimentalCondition-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalCondition-0.0.1",
     "description": "This describes the condition under which the data were collected, designed to be free form, extra things that do not fit in pre-defined terms",
     "type": "string"
 }

--- a/terms/cancer/experimentalCondition.json
+++ b/terms/cancer/experimentalCondition.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalCondition-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalCondition-0.0.2",
     "description": "This describes the condition under which the data were collected, designed to be free form, extra things that do not fit in pre-defined terms",
     "type": "string"
 }

--- a/terms/cancer/experimentalTimePoint.json
+++ b/terms/cancer/experimentalTimePoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalTimePoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalTimePoint-0.0.2",
     "description": "Number describing time point at which data was collected",
     "type": "string"
 }

--- a/terms/cancer/experimentalTimePoint.json
+++ b/terms/cancer/experimentalTimePoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.experimentalTimePoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalTimePoint-0.0.1",
     "description": "Number describing time point at which data was collected",
     "type": "string"
 }

--- a/terms/cancer/genePerturbationTechnology.json
+++ b/terms/cancer/genePerturbationTechnology.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationTechnology-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationTechnology-0.0.2",
     "description": "Technology used to perform gene perturbation",
     "anyOf": [
         {

--- a/terms/cancer/genePerturbationTechnology.json
+++ b/terms/cancer/genePerturbationTechnology.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbationTechnology-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationTechnology-0.0.1",
     "description": "Technology used to perform gene perturbation",
     "anyOf": [
         {

--- a/terms/cancer/genePerturbationType.json
+++ b/terms/cancer/genePerturbationType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationType-0.0.2",
     "description": "Specific way in which a single gene was perturbed in a sample",
     "anyOf": [
         {

--- a/terms/cancer/genePerturbationType.json
+++ b/terms/cancer/genePerturbationType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationType-0.0.1",
     "description": "Specific way in which a single gene was perturbed in a sample",
     "anyOf": [
         {

--- a/terms/cancer/genePerturbed.json
+++ b/terms/cancer/genePerturbed.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbed-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbed-0.0.2",
     "description": "In the case of gene modulation, this describes the gene or genes that were modulated",
     "type": "string"
 }

--- a/terms/cancer/genePerturbed.json
+++ b/terms/cancer/genePerturbed.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbed-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbed-0.0.1",
     "description": "In the case of gene modulation, this describes the gene or genes that were modulated",
     "type": "string"
 }

--- a/terms/cancer/timePointUnit.json
+++ b/terms/cancer/timePointUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.timePointUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.timePointUnit-0.0.1",
     "description": "For timed experiments this represents the unit of time measured",
     "anyOf": [
         {

--- a/terms/cancer/timePointUnit.json
+++ b/terms/cancer/timePointUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.timePointUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.timePointUnit-0.0.2",
     "description": "For timed experiments this represents the unit of time measured",
     "anyOf": [
         {

--- a/terms/cancer/transplantationDonorTissue.json
+++ b/terms/cancer/transplantationDonorTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationDonorTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationDonorTissue-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/cancer/transplantationDonorTissue.json
+++ b/terms/cancer/transplantationDonorTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationDonorTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationDonorTissue-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/cancer/transplantationRecipientSpecies.json
+++ b/terms/cancer/transplantationRecipientSpecies.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientSpecies-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientSpecies-0.0.2",
     "description": "Species into which donor tissue was grown",
     "anyOf": [
         {

--- a/terms/cancer/transplantationRecipientSpecies.json
+++ b/terms/cancer/transplantationRecipientSpecies.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationRecipientSpecies-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientSpecies-0.0.1",
     "description": "Species into which donor tissue was grown",
     "anyOf": [
         {

--- a/terms/cancer/transplantationRecipientTissue.json
+++ b/terms/cancer/transplantationRecipientTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientTissue-0.0.2",
     "description": "In the case of a transplate, this describes the transplant destination",
     "type": "string"
 }

--- a/terms/cancer/transplantationRecipientTissue.json
+++ b/terms/cancer/transplantationRecipientTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationRecipientTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientTissue-0.0.1",
     "description": "In the case of a transplate, this describes the transplant destination",
     "type": "string"
 }

--- a/terms/cancer/transplantationType.json
+++ b/terms/cancer/transplantationType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationType-0.0.2",
     "description": "Type of transplantation involved in the experiment, derived from MESH",
     "anyOf": [
         {

--- a/terms/cancer/transplantationType.json
+++ b/terms/cancer/transplantationType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationType-0.0.1",
     "description": "Type of transplantation involved in the experiment, derived from MESH",
     "anyOf": [
         {

--- a/terms/cancer/tumorType.json
+++ b/terms/cancer/tumorType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.tumorType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.tumorType-0.0.2",
     "description": "The type of cells that carcinoma arises from.",
     "anyOf": [
         {

--- a/terms/cancer/tumorType.json
+++ b/terms/cancer/tumorType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.tumorType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.tumorType-0.0.1",
     "description": "The type of cells that carcinoma arises from.",
     "anyOf": [
         {

--- a/terms/chem/chemicalDataType.json
+++ b/terms/chem/chemicalDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDataType-0.0.2",
     "description": "The type of chemical data in the dataset.",
     "anyOf": [
         {

--- a/terms/chem/chemicalDataType.json
+++ b/terms/chem/chemicalDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDataType-0.0.1",
     "description": "The type of chemical data in the dataset.",
     "anyOf": [
         {

--- a/terms/chem/chemicalDatabase.json
+++ b/terms/chem/chemicalDatabase.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDatabase-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDatabase-0.0.2",
     "description": "The chemical database from which the data were obtained.",
     "type": "string"
 }

--- a/terms/chem/chemicalDatabase.json
+++ b/terms/chem/chemicalDatabase.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalDatabase-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDatabase-0.0.1",
     "description": "The chemical database from which the data were obtained.",
     "type": "string"
 }

--- a/terms/chem/chemicalStructure.json
+++ b/terms/chem/chemicalStructure.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalStructure-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalStructure-0.0.1",
     "description": "A linear representation of the chemical structure (SMILES, SMARTS, InChI, InChIKey, etc). Note the format using structureFormat.",
     "type": "string"
 }

--- a/terms/chem/chemicalStructure.json
+++ b/terms/chem/chemicalStructure.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalStructure-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalStructure-0.0.2",
     "description": "A linear representation of the chemical structure (SMILES, SMARTS, InChI, InChIKey, etc). Note the format using structureFormat.",
     "type": "string"
 }

--- a/terms/chem/fingerprintType.json
+++ b/terms/chem/fingerprintType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.fingerprintType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.fingerprintType-0.0.2",
     "description": "The type of chemical fingerprint used.",
     "anyOf": [
         {

--- a/terms/chem/fingerprintType.json
+++ b/terms/chem/fingerprintType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.fingerprintType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.fingerprintType-0.0.1",
     "description": "The type of chemical fingerprint used.",
     "anyOf": [
         {

--- a/terms/chem/structureFormat.json
+++ b/terms/chem/structureFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.structureFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.structureFormat-0.0.1",
     "description": "The chemical structural representation used.",
     "anyOf": [
         {

--- a/terms/chem/structureFormat.json
+++ b/terms/chem/structureFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.structureFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.structureFormat-0.0.2",
     "description": "The chemical structural representation used.",
     "anyOf": [
         {

--- a/terms/compoundScreen/compoundDose.json
+++ b/terms/compoundScreen/compoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDose-0.0.1",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/compoundDose.json
+++ b/terms/compoundScreen/compoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDose-0.0.2",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/compoundDoseRange.json
+++ b/terms/compoundScreen/compoundDoseRange.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseRange-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseRange-0.0.2",
     "description": "The minimum and maximum values of a treatment range; e.g. 1-25",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundDoseRange.json
+++ b/terms/compoundScreen/compoundDoseRange.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDoseRange-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseRange-0.0.1",
     "description": "The minimum and maximum values of a treatment range; e.g. 1-25",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundDoseUnit.json
+++ b/terms/compoundScreen/compoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseUnit-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundDoseUnit.json
+++ b/terms/compoundScreen/compoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseUnit-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundName.json
+++ b/terms/compoundScreen/compoundName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundName-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/compoundScreen/compoundName.json
+++ b/terms/compoundScreen/compoundName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundName-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/compoundScreen/drugScreenType.json
+++ b/terms/compoundScreen/drugScreenType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.drugScreenType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.drugScreenType-0.0.2",
     "description": "String describing general class of drug screen",
     "anyOf": [
         {

--- a/terms/compoundScreen/drugScreenType.json
+++ b/terms/compoundScreen/drugScreenType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.drugScreenType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.drugScreenType-0.0.1",
     "description": "String describing general class of drug screen",
     "anyOf": [
         {

--- a/terms/compoundScreen/secondCompoundDose.json
+++ b/terms/compoundScreen/secondCompoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDose-0.0.1",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/secondCompoundDose.json
+++ b/terms/compoundScreen/secondCompoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDose-0.0.2",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/secondCompoundDoseUnit.json
+++ b/terms/compoundScreen/secondCompoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/secondCompoundDoseUnit.json
+++ b/terms/compoundScreen/secondCompoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/secondCompoundName.json
+++ b/terms/compoundScreen/secondCompoundName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundName-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/compoundScreen/secondCompoundName.json
+++ b/terms/compoundScreen/secondCompoundName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundName-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/curatedData/curatedDataSource.json
+++ b/terms/curatedData/curatedDataSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataSource-0.0.2",
     "description": "The database or curator of the curated data.",
     "type": "string"
 }

--- a/terms/curatedData/curatedDataSource.json
+++ b/terms/curatedData/curatedDataSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.curatedDataSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataSource-0.0.1",
     "description": "The database or curator of the curated data.",
     "type": "string"
 }

--- a/terms/curatedData/curatedDataType.json
+++ b/terms/curatedData/curatedDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.curatedDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataType-0.0.1",
     "description": "The type of information being curated.",
     "anyOf": [
         {

--- a/terms/curatedData/curatedDataType.json
+++ b/terms/curatedData/curatedDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataType-0.0.2",
     "description": "The type of information being curated.",
     "anyOf": [
         {

--- a/terms/curatedData/referenceSet.json
+++ b/terms/curatedData/referenceSet.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.referenceSet-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.referenceSet-0.0.2",
     "description": "A set of references (e.g., canonical assembled contigs) which defines a common coordinate space for comparing reference-aligned experimental data.",
     "anyOf": [
         {

--- a/terms/curatedData/referenceSet.json
+++ b/terms/curatedData/referenceSet.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.referenceSet-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.referenceSet-0.0.3",
     "description": "A set of references (e.g., canonical assembled contigs) which defines a common coordinate space for comparing reference-aligned experimental data.",
     "anyOf": [
         {

--- a/terms/dhart/caseNumber.json
+++ b/terms/dhart/caseNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.caseNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.caseNumber-0.0.1",
     "description": "This is the case number from the virtual repository",
     "type": "string"
 }

--- a/terms/dhart/caseNumber.json
+++ b/terms/dhart/caseNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.caseNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.caseNumber-0.0.2",
     "description": "This is the case number from the virtual repository",
     "type": "string"
 }

--- a/terms/dhart/collectionDate.json
+++ b/terms/dhart/collectionDate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.collectionDate-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.collectionDate-0.0.1",
     "description": "The date when this was collected",
     "type": "string"
 }

--- a/terms/dhart/collectionDate.json
+++ b/terms/dhart/collectionDate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.collectionDate-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.collectionDate-0.0.2",
     "description": "The date when this was collected",
     "type": "string"
 }

--- a/terms/dhart/projectNumber.json
+++ b/terms/dhart/projectNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.projectNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.projectNumber-0.0.1",
     "description": "There are four projects on going in the spore. This describes for which one the data was collected.",
     "anyOf": [
         {

--- a/terms/dhart/projectNumber.json
+++ b/terms/dhart/projectNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.projectNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.projectNumber-0.0.2",
     "description": "There are four projects on going in the spore. This describes for which one the data was collected.",
     "anyOf": [
         {

--- a/terms/dhart/specimenQuantity.json
+++ b/terms/dhart/specimenQuantity.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.specimenQuantity-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.specimenQuantity-0.0.1",
     "description": "Currently unused, but could be used to describe how much specimen remains",
     "type": "string"
 }

--- a/terms/dhart/specimenQuantity.json
+++ b/terms/dhart/specimenQuantity.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.specimenQuantity-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.specimenQuantity-0.0.2",
     "description": "Currently unused, but could be used to describe how much specimen remains",
     "type": "string"
 }

--- a/terms/dhart/studySite.json
+++ b/terms/dhart/studySite.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.studySite-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.studySite-0.0.2",
     "description": "This describes the site where the specimen was collected",
     "type": "string"
 }

--- a/terms/dhart/studySite.json
+++ b/terms/dhart/studySite.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.studySite-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.studySite-0.0.1",
     "description": "This describes the site where the specimen was collected",
     "type": "string"
 }

--- a/terms/experimentalData/assay.json
+++ b/terms/experimentalData/assay.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.assay-0.0.4",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assay-0.0.4",
     "description": "The technology used to generate the data in this file",
     "anyOf": [
         {

--- a/terms/experimentalData/assay.json
+++ b/terms/experimentalData/assay.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assay-0.0.4",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assay-0.0.5",
     "description": "The technology used to generate the data in this file",
     "anyOf": [
         {

--- a/terms/experimentalData/assayTarget.json
+++ b/terms/experimentalData/assayTarget.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assayTarget-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assayTarget-0.0.3",
     "description": "",
     "anyOf": [
         {

--- a/terms/experimentalData/assayTarget.json
+++ b/terms/experimentalData/assayTarget.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.assayTarget-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assayTarget-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/experimentalData/batchSize.json
+++ b/terms/experimentalData/batchSize.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.batchSize-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.batchSize-0.0.1",
     "description": "Size of batch",
     "type": "number"
 }

--- a/terms/experimentalData/batchSize.json
+++ b/terms/experimentalData/batchSize.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.batchSize-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.batchSize-0.0.2",
     "description": "Size of batch",
     "type": "number"
 }

--- a/terms/experimentalData/bodyPart.json
+++ b/terms/experimentalData/bodyPart.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.bodyPart-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bodyPart-0.0.1",
     "description": "Named areas of the body.",
     "anyOf": [
         {

--- a/terms/experimentalData/bodyPart.json
+++ b/terms/experimentalData/bodyPart.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bodyPart-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bodyPart-0.0.2",
     "description": "Named areas of the body.",
     "anyOf": [
         {

--- a/terms/experimentalData/brainWeight.json
+++ b/terms/experimentalData/brainWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.brainWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.brainWeight-0.0.1",
     "type": "number",
     "description": "Weight of brain in grams"
 }

--- a/terms/experimentalData/brainWeight.json
+++ b/terms/experimentalData/brainWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.brainWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.brainWeight-0.0.2",
     "type": "number",
     "description": "Weight of brain in grams"
 }

--- a/terms/experimentalData/cellLine.json
+++ b/terms/experimentalData/cellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLine-0.0.2",
     "description": "Identifying string linked to a particular cell line",
     "type": "string"
 }

--- a/terms/experimentalData/cellLine.json
+++ b/terms/experimentalData/cellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLine-0.0.1",
     "description": "Identifying string linked to a particular cell line",
     "type": "string"
 }

--- a/terms/experimentalData/cellLineSource.json
+++ b/terms/experimentalData/cellLineSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellLineSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLineSource-0.0.1",
     "description": "Identifying source of cell line, such as ATCC site",
     "type": "string"
 }

--- a/terms/experimentalData/cellLineSource.json
+++ b/terms/experimentalData/cellLineSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLineSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLineSource-0.0.2",
     "description": "Identifying source of cell line, such as ATCC site",
     "type": "string"
 }

--- a/terms/experimentalData/cellType.json
+++ b/terms/experimentalData/cellType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.3",
     "description": "A cell type is a distinct morphological or functional form of cell.",
     "anyOf": [
         {

--- a/terms/experimentalData/cellType.json
+++ b/terms/experimentalData/cellType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.2",
     "description": "A cell type is a distinct morphological or functional form of cell.",
     "anyOf": [
         {

--- a/terms/experimentalData/controlType.json
+++ b/terms/experimentalData/controlType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.controlType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.controlType-0.0.1",
     "description": "Control samples suitable for normalization and batch correction",
     "anyOf": [
         {

--- a/terms/experimentalData/controlType.json
+++ b/terms/experimentalData/controlType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.controlType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.controlType-0.0.2",
     "description": "Control samples suitable for normalization and batch correction",
     "anyOf": [
         {

--- a/terms/experimentalData/dataSubtype.json
+++ b/terms/experimentalData/dataSubtype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataSubtype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataSubtype-0.0.2",
     "description": "Further qualification of dataType, which may be used to indicate the state of processing of the data, aggregation of the data, or presence of metadata.",
     "anyOf": [
         {

--- a/terms/experimentalData/dataSubtype.json
+++ b/terms/experimentalData/dataSubtype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.dataSubtype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataSubtype-0.0.1",
     "description": "Further qualification of dataType, which may be used to indicate the state of processing of the data, aggregation of the data, or presence of metadata.",
     "anyOf": [
         {

--- a/terms/experimentalData/dataType.json
+++ b/terms/experimentalData/dataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.dataType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataType-0.0.2",
     "description": "Types of input/output data in bioinformatics pipelines",
     "anyOf": [
         {

--- a/terms/experimentalData/dataType.json
+++ b/terms/experimentalData/dataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataType-0.0.3",
     "description": "Types of input/output data in bioinformatics pipelines",
     "anyOf": [
         {

--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.diagnosis-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosis-0.0.3",
     "description": "A diagnosis is the result of a medical investigation to identify a disorder from its signs and symptoms.",
     "anyOf": [
         {

--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosis-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosis-0.0.4",
     "description": "A diagnosis is the result of a medical investigation to identify a disorder from its signs and symptoms.",
     "anyOf": [
         {

--- a/terms/experimentalData/diagnosisCriteria.json
+++ b/terms/experimentalData/diagnosisCriteria.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.diagnosisCriteria-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisCriteria-0.0.1",
   "type": "string",
   "description": "If a diagnosis is provided, the criteria it is based on"
 }

--- a/terms/experimentalData/diagnosisCriteria.json
+++ b/terms/experimentalData/diagnosisCriteria.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisCriteria-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisCriteria-0.0.2",
   "type": "string",
   "description": "If a diagnosis is provided, the criteria it is based on"
 }

--- a/terms/experimentalData/diagnosisDetail.json
+++ b/terms/experimentalData/diagnosisDetail.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisDetail-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisDetail-0.0.2",
   "type": "string",
   "description": "Subgroup of diagnosis (DSM or ICD code)"
 }

--- a/terms/experimentalData/diagnosisDetail.json
+++ b/terms/experimentalData/diagnosisDetail.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.diagnosisDetail-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisDetail-0.0.1",
   "type": "string",
   "description": "Subgroup of diagnosis (DSM or ICD code)"
 }

--- a/terms/experimentalData/exclude.json
+++ b/terms/experimentalData/exclude.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.exclude-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.exclude-0.0.2",
     "description": "Boolean flag indicating whether or not sample should be excluded from analysis",
     "type": "boolean"
 }

--- a/terms/experimentalData/exclude.json
+++ b/terms/experimentalData/exclude.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.exclude-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.exclude-0.0.1",
     "description": "Boolean flag indicating whether or not sample should be excluded from analysis",
     "type": "boolean"
 }

--- a/terms/experimentalData/excludeReason.json
+++ b/terms/experimentalData/excludeReason.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.excludeReason-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.excludeReason-0.0.1",
     "description": "Reason why a sample should be excluded from analysis",
     "type": "string"
 }

--- a/terms/experimentalData/excludeReason.json
+++ b/terms/experimentalData/excludeReason.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.excludeReason-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.excludeReason-0.0.2",
     "description": "Reason why a sample should be excluded from analysis",
     "type": "string"
 }

--- a/terms/experimentalData/failedQC.json
+++ b/terms/experimentalData/failedQC.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.failedQC-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.failedQC-0.0.1",
     "description": "Boolean flag indicating whether the sample or data failed QC checks",
     "anyOf": [
         {

--- a/terms/experimentalData/failedQC.json
+++ b/terms/experimentalData/failedQC.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.failedQC-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.failedQC-0.0.2",
     "description": "Boolean flag indicating whether the sample or data failed QC checks",
     "anyOf": [
         {

--- a/terms/experimentalData/individualID.json
+++ b/terms/experimentalData/individualID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualID-0.0.2",
     "description": "Identifying string linked to the individual or animal being studied",
     "type": "string"
 }

--- a/terms/experimentalData/individualID.json
+++ b/terms/experimentalData/individualID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.individualID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualID-0.0.1",
     "description": "Identifying string linked to the individual or animal being studied",
     "type": "string"
 }

--- a/terms/experimentalData/individualIdSource.json
+++ b/terms/experimentalData/individualIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualIdSource-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualIdSource-0.0.4",
     "description": "Database or repository to which individual ID maps",
     "anyOf": [
         {

--- a/terms/experimentalData/individualIdSource.json
+++ b/terms/experimentalData/individualIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.individualIdSource-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualIdSource-0.0.3",
     "description": "Database or repository to which individual ID maps",
     "anyOf": [
         {

--- a/terms/experimentalData/ionMode.json
+++ b/terms/experimentalData/ionMode.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ionMode-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ionMode-0.0.2",
     "description": "Ionization polarity (positive, negative, polar)",
     "type": "string"
 }

--- a/terms/experimentalData/ionMode.json
+++ b/terms/experimentalData/ionMode.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.ionMode-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ionMode-0.0.1",
     "description": "Ionization polarity (positive, negative, polar)",
     "type": "string"
 }

--- a/terms/experimentalData/isCellLine.json
+++ b/terms/experimentalData/isCellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isCellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isCellLine-0.0.2",
     "description": "Boolean flag indicating whether or not sample source is a cell line",
     "type": "boolean"
 }

--- a/terms/experimentalData/isCellLine.json
+++ b/terms/experimentalData/isCellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isCellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isCellLine-0.0.1",
     "description": "Boolean flag indicating whether or not sample source is a cell line",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiIndividual.json
+++ b/terms/experimentalData/isMultiIndividual.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiIndividual-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiIndividual-0.0.2",
     "description": "Boolean flag indicating whether or not a file has data for multiple individuals",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiIndividual.json
+++ b/terms/experimentalData/isMultiIndividual.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isMultiIndividual-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiIndividual-0.0.1",
     "description": "Boolean flag indicating whether or not a file has data for multiple individuals",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiSpecimen.json
+++ b/terms/experimentalData/isMultiSpecimen.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiSpecimen-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiSpecimen-0.0.2",
     "description": "Boolean flag indicating whether or not a file has data for multiple specimens",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiSpecimen.json
+++ b/terms/experimentalData/isMultiSpecimen.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isMultiSpecimen-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiSpecimen-0.0.1",
     "description": "Boolean flag indicating whether or not a file has data for multiple specimens",
     "type": "boolean"
 }

--- a/terms/experimentalData/isPrimaryCell.json
+++ b/terms/experimentalData/isPrimaryCell.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isPrimaryCell-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isPrimaryCell-0.0.1",
     "description": "Boolean flag indicating whether or not cellType is primary, defined as 'A cell taken directly from a living organism, which is not immortalized'.",
     "type": "boolean"
 }

--- a/terms/experimentalData/isPrimaryCell.json
+++ b/terms/experimentalData/isPrimaryCell.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isPrimaryCell-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isPrimaryCell-0.0.2",
     "description": "Boolean flag indicating whether or not cellType is primary, defined as 'A cell taken directly from a living organism, which is not immortalized'.",
     "type": "boolean"
 }

--- a/terms/experimentalData/metaboliteType.json
+++ b/terms/experimentalData/metaboliteType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.metaboliteType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metaboliteType-0.0.1",
     "description": "Class of metabolite.",
     "anyOf": [
         {

--- a/terms/experimentalData/metaboliteType.json
+++ b/terms/experimentalData/metaboliteType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metaboliteType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metaboliteType-0.0.2",
     "description": "Class of metabolite.",
     "anyOf": [
         {

--- a/terms/experimentalData/metadataType.json
+++ b/terms/experimentalData/metadataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metadataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metadataType-0.0.2",
     "description": "For files of dataSubtype: metadata, a description of the type of metadata in the file.",
     "anyOf": [
         {

--- a/terms/experimentalData/metadataType.json
+++ b/terms/experimentalData/metadataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.metadataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metadataType-0.0.1",
     "description": "For files of dataSubtype: metadata, a description of the type of metadata in the file.",
     "anyOf": [
         {

--- a/terms/experimentalData/organ.json
+++ b/terms/experimentalData/organ.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organ-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organ-0.0.3",
     "description": "A unique macroscopic (gross) anatomic structure that performs specific functions. It is composed of various tissues. An organ is part of an anatomic system or a body region.",
     "anyOf": [
         {

--- a/terms/experimentalData/organ.json
+++ b/terms/experimentalData/organ.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.organ-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organ-0.0.2",
     "description": "A unique macroscopic (gross) anatomic structure that performs specific functions. It is composed of various tissues. An organ is part of an anatomic system or a body region.",
     "anyOf": [
         {

--- a/terms/experimentalData/organWeight.json
+++ b/terms/experimentalData/organWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.organWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organWeight-0.0.1",
     "type": "number",
     "description": "Post-mortem weight of organ (in grams)"
 }

--- a/terms/experimentalData/organWeight.json
+++ b/terms/experimentalData/organWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organWeight-0.0.2",
     "type": "number",
     "description": "Post-mortem weight of organ (in grams)"
 }

--- a/terms/experimentalData/platform.json
+++ b/terms/experimentalData/platform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.platform-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platform-0.0.3",
     "description": "The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.",
     "anyOf": [
         {

--- a/terms/experimentalData/platform.json
+++ b/terms/experimentalData/platform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platform-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platform-0.0.4",
     "description": "The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.",
     "anyOf": [
         {

--- a/terms/experimentalData/platformLocation.json
+++ b/terms/experimentalData/platformLocation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.platformLocation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platformLocation-0.0.1",
     "description": "Laboratory where data generation platform was located",
     "type": "string"
 }

--- a/terms/experimentalData/platformLocation.json
+++ b/terms/experimentalData/platformLocation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platformLocation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platformLocation-0.0.2",
     "description": "Laboratory where data generation platform was located",
     "type": "string"
 }

--- a/terms/experimentalData/sex.json
+++ b/terms/experimentalData/sex.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.sex-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sex-0.0.1",
     "description": "Sex assigned at birth, or by sequencing",
     "anyOf": [
         {

--- a/terms/experimentalData/sex.json
+++ b/terms/experimentalData/sex.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sex-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sex-0.0.2",
     "description": "Sex assigned at birth, or by sequencing",
     "anyOf": [
         {

--- a/terms/experimentalData/species.json
+++ b/terms/experimentalData/species.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.species-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.species-0.0.2",
     "description": "The name of a species (typically a taxonomic group) of organism.",
     "anyOf": [
         {

--- a/terms/experimentalData/species.json
+++ b/terms/experimentalData/species.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.species-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.species-0.0.1",
     "description": "The name of a species (typically a taxonomic group) of organism.",
     "anyOf": [
         {

--- a/terms/experimentalData/specimenID.json
+++ b/terms/experimentalData/specimenID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.2",
     "description": "Identifying string linked to a particular sample or specimen",
     "type": "string"
 }

--- a/terms/experimentalData/specimenID.json
+++ b/terms/experimentalData/specimenID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.1",
     "description": "Identifying string linked to a particular sample or specimen",
     "type": "string"
 }

--- a/terms/experimentalData/specimenIdSource.json
+++ b/terms/experimentalData/specimenIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenIdSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenIdSource-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/experimentalData/specimenIdSource.json
+++ b/terms/experimentalData/specimenIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenIdSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenIdSource-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/experimentalData/terminalDifferentiationPoint.json
+++ b/terms/experimentalData/terminalDifferentiationPoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.1",
     "description": "The terminal differentiation point (TD) of a cell in days.",
     "type": "string"
 }

--- a/terms/experimentalData/terminalDifferentiationPoint.json
+++ b/terms/experimentalData/terminalDifferentiationPoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.2",
     "description": "The terminal differentiation point (TD) of a cell in days.",
     "type": "string"
 }

--- a/terms/experimentalData/tissue.json
+++ b/terms/experimentalData/tissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissue-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissue-0.0.3",
     "description": "A tissue is a mereologically maximal collection of cells that together perform physiological function.",
     "anyOf": [
         {

--- a/terms/experimentalData/tissue.json
+++ b/terms/experimentalData/tissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.tissue-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissue-0.0.2",
     "description": "A tissue is a mereologically maximal collection of cells that together perform physiological function.",
     "anyOf": [
         {

--- a/terms/experimentalData/tissueVolume.json
+++ b/terms/experimentalData/tissueVolume.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.tissueVolume-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissueVolume-0.0.1",
     "type": "number",
     "description": "Volume of tissue sample in microliters"
 }

--- a/terms/experimentalData/tissueVolume.json
+++ b/terms/experimentalData/tissueVolume.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissueVolume-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissueVolume-0.0.2",
     "type": "number",
     "description": "Volume of tissue sample in microliters"
 }

--- a/terms/genie/cBioFileFormat.json
+++ b/terms/genie/cBioFileFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.cBioFileFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.cBioFileFormat-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/genie/cBioFileFormat.json
+++ b/terms/genie/cBioFileFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.cBioFileFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.cBioFileFormat-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/genie/center.json
+++ b/terms/genie/center.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.center-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.center-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/genie/center.json
+++ b/terms/genie/center.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.center-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.center-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/genie/fileStage.json
+++ b/terms/genie/fileStage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.fileStage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.fileStage-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/genie/fileStage.json
+++ b/terms/genie/fileStage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.fileStage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.fileStage-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/immunoAssays/antibody.json
+++ b/terms/immunoAssays/antibody.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibody-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibody-0.0.2",
     "description": "An immunoglobulin complex that is secreted into extracellular space and found in mucosal areas or other tissues or circulating in the blood or lymph",
     "type": "string"
 }

--- a/terms/immunoAssays/antibody.json
+++ b/terms/immunoAssays/antibody.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibody-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibody-0.0.1",
     "description": "An immunoglobulin complex that is secreted into extracellular space and found in mucosal areas or other tissues or circulating in the blood or lymph",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyAmount.json
+++ b/terms/immunoAssays/antibodyAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmount-0.0.2",
     "description": "Amount of antibody used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyAmount.json
+++ b/terms/immunoAssays/antibodyAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmount-0.0.1",
     "description": "Amount of antibody used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyAmountUnits.json
+++ b/terms/immunoAssays/antibodyAmountUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyAmountUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmountUnits-0.0.1",
     "description": "Units of measure for the amount of antibody used for an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyAmountUnits.json
+++ b/terms/immunoAssays/antibodyAmountUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmountUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmountUnits-0.0.2",
     "description": "Units of measure for the amount of antibody used for an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyConcentration.json
+++ b/terms/immunoAssays/antibodyConcentration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyConcentration-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentration-0.0.1",
     "description": "Concentration of antibody used in an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyConcentration.json
+++ b/terms/immunoAssays/antibodyConcentration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentration-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentration-0.0.2",
     "description": "Concentration of antibody used in an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyConcentrationUnits.json
+++ b/terms/immunoAssays/antibodyConcentrationUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.1",
     "description": "Units of measure for the concentration of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyConcentrationUnits.json
+++ b/terms/immunoAssays/antibodyConcentrationUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.2",
     "description": "Units of measure for the concentration of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyDilution.json
+++ b/terms/immunoAssays/antibodyDilution.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyDilution-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyDilution-0.0.2",
     "description": "Ratio of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyDilution.json
+++ b/terms/immunoAssays/antibodyDilution.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyDilution-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyDilution-0.0.1",
     "description": "Ratio of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyOrder.json
+++ b/terms/immunoAssays/antibodyOrder.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyOrder-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyOrder-0.0.1",
     "description": "For ELISA assays, specifies whether the antibody was used as the primary or secondary antibody",
     "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5775980/",
     "type": "string",

--- a/terms/immunoAssays/antibodyOrder.json
+++ b/terms/immunoAssays/antibodyOrder.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyOrder-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyOrder-0.0.2",
     "description": "For ELISA assays, specifies whether the antibody was used as the primary or secondary antibody",
     "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5775980/",
     "type": "string",

--- a/terms/immunoAssays/catalogNumber.json
+++ b/terms/immunoAssays/catalogNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.catalogNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.catalogNumber-0.0.1",
     "description": "The identifier assigned to a product, usually in the list of products published by a reseller or manufacturer",
     "type": "string"
 }

--- a/terms/immunoAssays/catalogNumber.json
+++ b/terms/immunoAssays/catalogNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.catalogNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.catalogNumber-0.0.2",
     "description": "The identifier assigned to a product, usually in the list of products published by a reseller or manufacturer",
     "type": "string"
 }

--- a/terms/immunoAssays/chromatinAmount.json
+++ b/terms/immunoAssays/chromatinAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.chromatinAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.chromatinAmount-0.0.1",
     "description": "Amount in ug of chromatin used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/chromatinAmount.json
+++ b/terms/immunoAssays/chromatinAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.chromatinAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.chromatinAmount-0.0.2",
     "description": "Amount in ug of chromatin used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/lotNumber.json
+++ b/terms/immunoAssays/lotNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.lotNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.lotNumber-0.0.2",
     "description": "A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch",
     "type": "string"
 }

--- a/terms/immunoAssays/lotNumber.json
+++ b/terms/immunoAssays/lotNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.lotNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.lotNumber-0.0.1",
     "description": "A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch",
     "type": "string"
 }

--- a/terms/immunoAssays/vendor.json
+++ b/terms/immunoAssays/vendor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.vendor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.vendor-0.0.2",
     "description": "Commercial or institutional source of a component used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/vendor.json
+++ b/terms/immunoAssays/vendor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.vendor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.vendor-0.0.1",
     "description": "Commercial or institutional source of a component used in an assay",
     "type": "string"
 }

--- a/terms/network/networkEdgeType.json
+++ b/terms/network/networkEdgeType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-network.networkEdgeType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-network.networkEdgeType-0.0.1",
     "description": "Method used to derive the edge in a network",
     "anyOf": [
         {

--- a/terms/network/networkEdgeType.json
+++ b/terms/network/networkEdgeType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-network.networkEdgeType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-network.networkEdgeType-0.0.2",
     "description": "Method used to derive the edge in a network",
     "anyOf": [
         {

--- a/terms/neuro/BrodmannArea.json
+++ b/terms/neuro/BrodmannArea.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.BrodmannArea-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.BrodmannArea-0.0.1",
     "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture",
     "type": "string"
 }

--- a/terms/neuro/BrodmannArea.json
+++ b/terms/neuro/BrodmannArea.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.BrodmannArea-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.BrodmannArea-0.0.2",
     "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture",
     "type": "string"
 }

--- a/terms/neuro/PMI.json
+++ b/terms/neuro/PMI.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.PMI-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.PMI-0.0.3",
     "description": "Post-mortem interval",
     "type": "string"
 }

--- a/terms/neuro/PMI.json
+++ b/terms/neuro/PMI.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.PMI-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.PMI-0.0.2",
     "description": "Post-mortem interval",
     "type": "string"
 }

--- a/terms/neuro/fileSubFormat.json
+++ b/terms/neuro/fileSubFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.fileSubFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.fileSubFormat-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/fileSubFormat.json
+++ b/terms/neuro/fileSubFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.fileSubFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.fileSubFormat-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/grant.json
+++ b/terms/neuro/grant.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.grant-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.grant-0.0.2",
     "description": "Grant number including activity code, institute code, and serial number (e.g. U01MH103392)",
     "type": "string"
 }

--- a/terms/neuro/grant.json
+++ b/terms/neuro/grant.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.grant-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.grant-0.0.1",
     "description": "Grant number including activity code, institute code, and serial number (e.g. U01MH103392)",
     "type": "string"
 }

--- a/terms/neuro/hemisphere.json
+++ b/terms/neuro/hemisphere.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.hemisphere-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.hemisphere-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/hemisphere.json
+++ b/terms/neuro/hemisphere.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.hemisphere-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.hemisphere-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/isConsortiumAnalysis.json
+++ b/terms/neuro/isConsortiumAnalysis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isConsortiumAnalysis-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isConsortiumAnalysis-0.0.2",
     "description": "Collaborative consortium analysis",
     "type": "boolean"
 }

--- a/terms/neuro/isConsortiumAnalysis.json
+++ b/terms/neuro/isConsortiumAnalysis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.isConsortiumAnalysis-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isConsortiumAnalysis-0.0.1",
     "description": "Collaborative consortium analysis",
     "type": "boolean"
 }

--- a/terms/neuro/isModelSystem.json
+++ b/terms/neuro/isModelSystem.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.isModelSystem-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isModelSystem-0.0.1",
     "description": "",
     "type": "boolean"
 }

--- a/terms/neuro/isModelSystem.json
+++ b/terms/neuro/isModelSystem.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isModelSystem-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isModelSystem-0.0.2",
     "description": "",
     "type": "boolean"
 }

--- a/terms/neuro/modelSystemName.json
+++ b/terms/neuro/modelSystemName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemName-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemName-0.0.3",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/modelSystemName.json
+++ b/terms/neuro/modelSystemName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.modelSystemName-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemName-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/modelSystemStrainNomenclature.json
+++ b/terms/neuro/modelSystemStrainNomenclature.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemStrainNomenclature-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemStrainNomenclature-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/modelSystemStrainNomenclature.json
+++ b/terms/neuro/modelSystemStrainNomenclature.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.modelSystemStrainNomenclature-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemStrainNomenclature-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/pH.json
+++ b/terms/neuro/pH.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.pH-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.pH-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/neuro/pH.json
+++ b/terms/neuro/pH.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.pH-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.pH-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/neuro/study.json
+++ b/terms/neuro/study.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.study-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.study-0.0.3",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/study.json
+++ b/terms/neuro/study.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.study-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.study-0.0.4",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/treatmentType.json
+++ b/terms/neuro/treatmentType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/treatmentType.json
+++ b/terms/neuro/treatmentType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.treatmentType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/neuro/waterpH.json
+++ b/terms/neuro/waterpH.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.waterpH-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.waterpH-0.0.2",
   "description": "pH of water fed to the animal",
   "type": "number",
   "minimum": 0,

--- a/terms/neuro/waterpH.json
+++ b/terms/neuro/waterpH.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-neuro.waterpH-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.waterpH-0.0.1",
   "description": "pH of water fed to the animal",
   "type": "number",
   "minimum": 0,

--- a/terms/neurofibromatosis/nf1Genotype.json
+++ b/terms/neurofibromatosis/nf1Genotype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf1Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf1Genotype-0.0.2",
     "description": "Genotype of NF1 gene, if known",
     "anyOf": [
         {

--- a/terms/neurofibromatosis/nf1Genotype.json
+++ b/terms/neurofibromatosis/nf1Genotype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.nf1Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf1Genotype-0.0.1",
     "description": "Genotype of NF1 gene, if known",
     "anyOf": [
         {

--- a/terms/neurofibromatosis/nf2Genotype.json
+++ b/terms/neurofibromatosis/nf2Genotype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.nf2Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf2Genotype-0.0.1",
     "description": "Genotype of NF2 gene, if known",
     "anyOf": [
         {

--- a/terms/neurofibromatosis/nf2Genotype.json
+++ b/terms/neurofibromatosis/nf2Genotype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf2Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf2Genotype-0.0.2",
     "description": "Genotype of NF2 gene, if known",
     "anyOf": [
         {

--- a/terms/neurofibromatosis/reportMilestone.json
+++ b/terms/neurofibromatosis/reportMilestone.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.reportMilestone-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.reportMilestone-0.0.2",
     "description": "This key represents the milestone for which the report was submitted, a number representing number of months.",
     "type": "integer"
 }

--- a/terms/neurofibromatosis/reportMilestone.json
+++ b/terms/neurofibromatosis/reportMilestone.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.reportMilestone-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.reportMilestone-0.0.1",
     "description": "This key represents the milestone for which the report was submitted, a number representing number of months.",
     "type": "integer"
 }

--- a/terms/ngs/dissociationMethod.json
+++ b/terms/ngs/dissociationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.dissociationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.dissociationMethod-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/ngs/dissociationMethod.json
+++ b/terms/ngs/dissociationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.dissociationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.dissociationMethod-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/ngs/isStranded.json
+++ b/terms/ngs/isStranded.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.isStranded-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.isStranded-0.0.2",
     "description": "Whether or not the library is stranded.",
     "type": "boolean"
 }

--- a/terms/ngs/isStranded.json
+++ b/terms/ngs/isStranded.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.isStranded-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.isStranded-0.0.1",
     "description": "Whether or not the library is stranded.",
     "type": "boolean"
 }

--- a/terms/ngs/libraryPrep.json
+++ b/terms/ngs/libraryPrep.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPrep-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPrep-0.0.4",
     "description": "The general strategy by which the library was prepared",
     "anyOf": [
         {

--- a/terms/ngs/libraryPrep.json
+++ b/terms/ngs/libraryPrep.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.libraryPrep-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPrep-0.0.3",
     "description": "The general strategy by which the library was prepared",
     "anyOf": [
         {

--- a/terms/ngs/libraryPreparationMethod.json
+++ b/terms/ngs/libraryPreparationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.libraryPreparationMethod-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPreparationMethod-0.0.2",
     "description": "Method by which library was prepared",
     "anyOf": [
         {

--- a/terms/ngs/libraryPreparationMethod.json
+++ b/terms/ngs/libraryPreparationMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPreparationMethod-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPreparationMethod-0.0.3",
     "description": "Method by which library was prepared",
     "anyOf": [
         {

--- a/terms/ngs/nucleicAcidSource.json
+++ b/terms/ngs/nucleicAcidSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.nucleicAcidSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.nucleicAcidSource-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/ngs/nucleicAcidSource.json
+++ b/terms/ngs/nucleicAcidSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.nucleicAcidSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.nucleicAcidSource-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/ngs/readLength.json
+++ b/terms/ngs/readLength.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readLength-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readLength-0.0.1",
     "description": "The length of the read",
     "type": "string"
 }

--- a/terms/ngs/readLength.json
+++ b/terms/ngs/readLength.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readLength-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readLength-0.0.2",
     "description": "The length of the read",
     "type": "string"
 }

--- a/terms/ngs/readPair.json
+++ b/terms/ngs/readPair.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readPair-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPair-0.0.1",
     "description": "The read of origin",
     "anyOf": [
         {

--- a/terms/ngs/readPair.json
+++ b/terms/ngs/readPair.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPair-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPair-0.0.2",
     "description": "The read of origin",
     "anyOf": [
         {

--- a/terms/ngs/readPairOrientation.json
+++ b/terms/ngs/readPairOrientation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPairOrientation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPairOrientation-0.0.2",
     "description": "The relative orientation of the reads in a paired-end protocol",
     "anyOf": [
         {

--- a/terms/ngs/readPairOrientation.json
+++ b/terms/ngs/readPairOrientation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readPairOrientation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPairOrientation-0.0.1",
     "description": "The relative orientation of the reads in a paired-end protocol",
     "anyOf": [
         {

--- a/terms/ngs/readStrandOrigin.json
+++ b/terms/ngs/readStrandOrigin.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readStrandOrigin-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readStrandOrigin-0.0.2",
     "description": "The strand from which the read originates in a strand-specific protocol",
     "anyOf": [
         {

--- a/terms/ngs/readStrandOrigin.json
+++ b/terms/ngs/readStrandOrigin.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readStrandOrigin-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readStrandOrigin-0.0.1",
     "description": "The strand from which the read originates in a strand-specific protocol",
     "anyOf": [
         {

--- a/terms/ngs/runType.json
+++ b/terms/ngs/runType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.runType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.runType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/ngs/runType.json
+++ b/terms/ngs/runType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.runType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.runType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/sageCommunity/consortium.json
+++ b/terms/sageCommunity/consortium.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.consortium-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.consortium-0.0.2",
     "description": "The name of the consortium",
     "anyOf": [
         {

--- a/terms/sageCommunity/consortium.json
+++ b/terms/sageCommunity/consortium.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.consortium-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.consortium-0.0.3",
     "description": "The name of the consortium",
     "anyOf": [
         {

--- a/terms/sageCommunity/fileFormat.json
+++ b/terms/sageCommunity/fileFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.fileFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fileFormat-0.0.1",
     "description": "Defined format of the data file, typically corresponding to extension, but sometimes indicating more general group of files produced by the same tool or software",
     "anyOf": [
         {

--- a/terms/sageCommunity/fileFormat.json
+++ b/terms/sageCommunity/fileFormat.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fileFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fileFormat-0.0.2",
     "description": "Defined format of the data file, typically corresponding to extension, but sometimes indicating more general group of files produced by the same tool or software",
     "anyOf": [
         {

--- a/terms/sageCommunity/fundingAgency.json
+++ b/terms/sageCommunity/fundingAgency.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fundingAgency-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fundingAgency-0.0.2",
     "description": "The organization providing financial support for generation of this data.",
     "anyOf": [
         {

--- a/terms/sageCommunity/fundingAgency.json
+++ b/terms/sageCommunity/fundingAgency.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.fundingAgency-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fundingAgency-0.0.1",
     "description": "The organization providing financial support for generation of this data.",
     "anyOf": [
         {

--- a/terms/sageCommunity/group.json
+++ b/terms/sageCommunity/group.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.group-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.group-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/sageCommunity/group.json
+++ b/terms/sageCommunity/group.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.group-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.group-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/sageCommunity/resourceType.json
+++ b/terms/sageCommunity/resourceType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.resourceType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.resourceType-0.0.1",
     "description": "The type of resource being stored and annotated",
     "anyOf": [
         {

--- a/terms/sageCommunity/resourceType.json
+++ b/terms/sageCommunity/resourceType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.resourceType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.resourceType-0.0.2",
     "description": "The type of resource being stored and annotated",
     "anyOf": [
         {

--- a/terms/tool/inputDataType.json
+++ b/terms/tool/inputDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.inputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.inputDataType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/inputDataType.json
+++ b/terms/tool/inputDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.inputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.inputDataType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/outputDataType.json
+++ b/terms/tool/outputDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.outputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.outputDataType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/outputDataType.json
+++ b/terms/tool/outputDataType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.outputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.outputDataType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareAuthor.json
+++ b/terms/tool/softwareAuthor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareAuthor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareAuthor-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareAuthor.json
+++ b/terms/tool/softwareAuthor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareAuthor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareAuthor-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareLanguage.json
+++ b/terms/tool/softwareLanguage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguage-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareLanguage.json
+++ b/terms/tool/softwareLanguage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareLanguage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguage-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareLanguageVersion.json
+++ b/terms/tool/softwareLanguageVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareLanguageVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguageVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareLanguageVersion.json
+++ b/terms/tool/softwareLanguageVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguageVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguageVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareName.json
+++ b/terms/tool/softwareName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareName-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareName.json
+++ b/terms/tool/softwareName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareName-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareRepository.json
+++ b/terms/tool/softwareRepository.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepository-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepository-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareRepository.json
+++ b/terms/tool/softwareRepository.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareRepository-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepository-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareRepositoryType.json
+++ b/terms/tool/softwareRepositoryType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepositoryType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepositoryType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareRepositoryType.json
+++ b/terms/tool/softwareRepositoryType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareRepositoryType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepositoryType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareType.json
+++ b/terms/tool/softwareType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareType-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareType.json
+++ b/terms/tool/softwareType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareType-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/tool/softwareVersion.json
+++ b/terms/tool/softwareVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareVersion.json
+++ b/terms/tool/softwareVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/containerPlatform.json
+++ b/terms/toolExtended/containerPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatform-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/containerPlatform.json
+++ b/terms/toolExtended/containerPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatform-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/containerPlatformVersion.json
+++ b/terms/toolExtended/containerPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/containerPlatformVersion.json
+++ b/terms/toolExtended/containerPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatformVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/containerToolPlatform.json
+++ b/terms/toolExtended/containerToolPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerToolPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerToolPlatform-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/containerToolPlatform.json
+++ b/terms/toolExtended/containerToolPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerToolPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerToolPlatform-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/packageBinaryPlatform.json
+++ b/terms/toolExtended/packageBinaryPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageBinaryPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatform-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/packageBinaryPlatform.json
+++ b/terms/toolExtended/packageBinaryPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatform-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/packageBinaryPlatformVersion.json
+++ b/terms/toolExtended/packageBinaryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/packageBinaryPlatformVersion.json
+++ b/terms/toolExtended/packageBinaryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/packageLibraryPlatformVersion.json
+++ b/terms/toolExtended/packageLibraryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/packageLibraryPlatformVersion.json
+++ b/terms/toolExtended/packageLibraryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/workflowPlatform.json
+++ b/terms/toolExtended/workflowPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.workflowPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatform-0.0.1",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/workflowPlatform.json
+++ b/terms/toolExtended/workflowPlatform.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatform-0.0.2",
     "description": "",
     "anyOf": [
         {

--- a/terms/toolExtended/workflowPlatformVersion.json
+++ b/terms/toolExtended/workflowPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.workflowPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatformVersion-0.0.1",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/workflowPlatformVersion.json
+++ b/terms/toolExtended/workflowPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }


### PR DESCRIPTION
Per [PLFM-6515](https://sagebionetworks.jira.com/browse/PLFM-6515), schemas should have absolute paths in their `$id` field. This PR updates all of the schemas' IDs, and also increments each version number (since this is a change to the schemas). `$ref`s still use relative paths.

Note that these schemas won't be able to be registered until stack-338 is deployed to prod (hence the draft PR)