### PR TITLE
Add tissues for microbiome studies

### DIFF
--- a/terms/experimentalData/tissue.json
+++ b/terms/experimentalData/tissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.tissue-0.0.2",
+    "$id": "sage.annotations-experimentalData.tissue-0.0.3",
     "description": "A tissue is a mereologically maximal collection of cells that together perform physiological function.",
     "anyOf": [
         {
@@ -367,6 +367,21 @@
             "const": "insular cortex",
             "description": "insular cortex",
             "source": "http://purl.obolibrary.org/obo/UBERON_0034891"
+        },
+        {
+            "const": "liver",
+            "description": "Liver tissue sample",
+            "source": "http://purl.obolibrary.org/obo/UBERON_0002107"
+        },
+        {
+            "const": "cecum derived fecal material",
+            "description": "Fecal material collected from the cecum",
+            "source": "Sage Bionetworks"
+        },
+        {
+            "const": "fecal material",
+            "description": "An excreta material which is composed primarily of feces, an excreta consisting of waste products expelled from an animal's digestive tract through the anus (or cloaca) during defecation.",
+            "source": "http://purl.obolibrary.org/obo/ENVO_00002003"
         }
     ]
 }


### PR DESCRIPTION
Splitting hairs on whether some of these are actually "tissues," but we are using these in AD to differentiate between sample types for microbiome studies.