### PR TITLE
Add SentrixID and SentrixRowColumn

### DIFF
--- a/terms/experimentalData/SentrixID.json
+++ b/terms/experimentalData/SentrixID.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "sage.annotations-experimentalData.SentrixID-0.0.1",
+    "description": "BeadChip ID in Illumina array-based assay",
+    "type": "string"
+}
+

--- a/terms/experimentalData/SentrixRowColumn.json
+++ b/terms/experimentalData/SentrixRowColumn.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "sage.annotations-experimentalData.SentrixRowColumn-0.0.1",
+    "description": "Position of sample on BeadChip in Illumina array-based assay",
+    "type": "string"
+}
+


### PR DESCRIPTION
Add SentrixID and SentrixRowColumn as new keys. These are terms from Illumina's BeadChip technology for their array-based assays. The SentrixID is the chip ID and the SentrixRowColumn is the position of the sample in the chip.

I put this in experimentalData. Should these be in a different module?