### PR TITLE
Add fluorphore and elisaType

### DIFF
--- a/terms/immunoAssays/elisaType.json
+++ b/terms/immunoAssays/elisaType.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "sage.annotations-immunoAssays.elisaType-0.0.1",
+    "description": "Type of ELISA assay",
+    "anyOf": [
+        {
+            "const": "direct",
+            "description": "A single, primary detection antibody was bound to the protein of interest.",
+            "source": "https://www.ncbi.nlm.nih.gov/books/NBK555922/"
+        },
+        {
+            "const": "indirect",
+            "description": "Detection was done via two antibodies. A secondary enzyme-linked antibody bound to the primary detection antibody, which is bound to the protein of interest.",
+            "source": "https://www.ncbi.nlm.nih.gov/books/NBK555922/"
+        },
+        {
+            "const": "sandwich",
+            "description": "The antigen of interest is bound between two antibodies, a capture and a detection antibody.",
+            "source": "https://www.ncbi.nlm.nih.gov/books/NBK555922/"
+        },
+        {
+            "const": "competitive",
+            "description": "Two antibodies are used, an enzyme-conjugated antibody and an antibody that is present in the serum, if the serum is positive. The two antibodies compete to bind to the antigen of interest",
+            "source": "https://www.ncbi.nlm.nih.gov/books/NBK555922/"
+        }
+    ]
+}
+

--- a/terms/immunoAssays/fluorophore.json
+++ b/terms/immunoAssays/fluorophore.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "sage.annotations-immunoAssays.fluorophore-0.0.1",
+    "description": " A fluorophore is a component of a molecule which causes a molecule to be fluorescent. It is a functional group in a molecule which will absorb energy of a specific wavelength and re-emit energy at a different (but equally specific) wavelength. The amount and wavelength of the emitted energy depend on both the fluorophore and the chemical environment of the fluorophore.",
+    "type": "string"
+}
+


### PR DESCRIPTION
fluorophore seems straightforward.

elisaType relates to the ELISA assay. Technically, we have assay terms like "sandwich ELISA" that would cover this term. However, the idea for this was to be able to have an "ELISA" assay (simpler for queries) and just specify the type. Not sure if we want to keep this, though. @amapeters, thoughts on this?