### PR TITLE
Fix odd spacing character

### DIFF
--- a/terms/experimentalData/reprogrammedCellType.json
+++ b/terms/experimentalData/reprogrammedCellType.json
@@ -6,6 +6,6 @@
         "reprogrammedCellType": {
             "$ref": "sage.annotations-experimentalData.cellType"
         }
-   	}
+    }
 }
 


### PR DESCRIPTION
I thought I had removed all the odd spacing characters, but missed one. Spacing _should_ be fine now.