### PR TITLE
Table script update: allow referencing values of a different term

### DIFF
--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -54,7 +54,7 @@ add_enumerated_values <- function(data_table, json_list) {
       mutate(value = as.character(value))
   return_df <- full_join(data_table, enum_df, by = character())
   ## If no value had a source, then need to add this column
-  if (!("source" %in% names(dat))) {
+  if (!("source" %in% names(return_df))) {
     return_df <- return_df %>%
       add_column(source = NA)
   }

--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -20,7 +20,11 @@ library("here")
 #' @return The module or key name
 get_info <- function(id, info = c("module", "key")) {
   info <- match.arg(info)
-  pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)-[0-9\\.]+"
+  if (grepl("-[0-9\\.]+", id)) {
+    pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)-[0-9\\.]+"
+  } else {
+    pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)"
+  }
   switch(
     info,
     module = gsub(pattern, "\\1", id),
@@ -28,12 +32,45 @@ get_info <- function(id, info = c("module", "key")) {
   )
 }
 
+#' Extract file path from referenced id
+#'
+#' @param id string containing the schema `$id`
+#' @return The local file path to the schema for the `$id`
+get_ref_path <- function(id) {
+  module <- get_info(id, "module")
+  key <- get_info(id, "key")
+  glue::glue("{here('terms')}/{module}/{key}.json")
+}
+
+#' Append enumerated values for a term
+#'
+#' @param data_table Table with columns key, description, columnType, module,
+#' maximumSize for adding the enumerated values of the key to
+#' @param json_list List of json data from the file
+#' @return Table with columns key, description, columnType, module, maximumSize,
+#' value, valueDescription, source, with one row per enumerated value
+add_enumerated_values <- function(data_table, json_list) {
+  enum_df <- json_list[["anyOf"]] %>%
+    rename(
+      value = const,
+      valueDescription = description
+    ) %>%
+      mutate(value = as.character(value))
+  return_df <- full_join(data_table, enum_df, by = character())
+  ## If no value had a source, then need to add this column
+  if (!("source" %in% names(dat))) {
+    return_df <- return_df %>%
+      add_column(source = NA)
+  }
+  return(return_df)
+}
+
 #' Create table row(s) for a term
 #'
 #' @param file Path to the JSON Schema file containing a term
 #' @return
 create_rows <- function(file) {
-  dat <- fromJSON(file)
+dat <- fromJSON(file)
   ## Information about the key
   return_df <- tibble::tibble(
     key = get_info(dat$`$id`, "key"),
@@ -45,23 +82,22 @@ create_rows <- function(file) {
   ## If term has enumerated values in anyOf, fromJSON will create a handy data
   ## frame of those. We use that in combination with return_df to create a row
   ## for each value.
+  ## If term references the enumerated values of another term, grab those
+  ## File referenced should exist in current set
   if ("anyOf" %in% names(dat)) {
-    enum_df <- dat[["anyOf"]] %>%
-      rename(
-        value = const,
-        valueDescription = description
-      ) %>%
-      mutate(value = as.character(value))
-    return_df <- full_join(return_df, enum_df, by = character())
-    ## If no value had a source, then need to add this column
-    if (!("source" %in% names(return_df))) {
-      return_df <- return_df %>%
-        add_column(source = NA)
-    }
+    return_df <- add_enumerated_values(data_table = return_df, json_list = dat)
+  } else if ("properties" %in% names(dat)) {
+    # Assume will be a reference to existing file with enumerated values
+    alias_dat <- fromJSON(get_ref_path(dat$properties[[return_df$key]]$`$ref`))
+    return_df <- add_enumerated_values(
+      data_table = return_df,
+      json_list = alias_dat
+    )
   } else {
     return_df <- return_df %>%
-      add_column(value = NA, valueDescription = NA, source = NA)
+    add_column(value = NA, valueDescription = NA, source = NA)
   }
+
   ## Select columns in order that matches the table schema
   select(
     return_df,

--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -83,7 +83,7 @@ create_rows <- function(file) {
   ## for each value.
   ## If term references the enumerated values of another term, grab those. Term
   ## cannot extend the values in a referenced schema. Schema referenced should
-  ## exist in current set of.
+  ## exist in current set of schema files.
   if ("anyOf" %in% names(dat)) {
     return_df <- add_enumerated_values(data_table = return_df, json_list = dat)
   } else if ("properties" %in% names(dat)) {

--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -20,11 +20,7 @@ library("here")
 #' @return The module or key name
 get_info <- function(id, info = c("module", "key")) {
   info <- match.arg(info)
-  if (grepl("-[0-9\\.]+", id)) {
-    pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)-[0-9\\.]+"
-  } else {
-    pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)"
-  }
+  pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)-[0-9\\.]+"
   switch(
     info,
     module = gsub(pattern, "\\1", id),

--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -67,10 +67,13 @@ add_enumerated_values <- function(data_table, json_list) {
 
 #' Create table row(s) for a term
 #'
-#' @param file Path to the JSON Schema file containing a term
+#' @param file Path to the JSON Schema file containing a term. For terms that
+#' reference enumerated values of a different term, the referenced term
+#' should exist as a file in the current set. The referenced term cannot be
+#' extended.
 #' @return
 create_rows <- function(file) {
-dat <- fromJSON(file)
+  dat <- fromJSON(file)
   ## Information about the key
   return_df <- tibble::tibble(
     key = get_info(dat$`$id`, "key"),
@@ -82,8 +85,9 @@ dat <- fromJSON(file)
   ## If term has enumerated values in anyOf, fromJSON will create a handy data
   ## frame of those. We use that in combination with return_df to create a row
   ## for each value.
-  ## If term references the enumerated values of another term, grab those
-  ## File referenced should exist in current set
+  ## If term references the enumerated values of another term, grab those. Term
+  ## cannot extend the values in a referenced schema. Schema referenced should
+  ## exist in current set of.
   if ("anyOf" %in% names(dat)) {
     return_df <- add_enumerated_values(data_table = return_df, json_list = dat)
   } else if ("properties" %in% names(dat)) {


### PR DESCRIPTION
There are cases in which we want a term with a specific definition, but that has the same enumerated list of values as a different term. The example case is [reprogrammedCellType](https://github.com/Sage-Bionetworks/synapseAnnotations/blob/master/terms/experimentalData/reprogrammedCellType.json), which should be in sync with cellType.

This script update allows for doing this. When the table is generated, every value in cellType has two rows: one with the key cellType and the cellType definition, one with the key reprogrammedCellType and the reprogrammedCellType definition.

Assumptions/restrictions:
- Does not allow for extending terms. This will only allow for referencing the values in **one** other schema, with no additional values.
- Reference is done via `property`, where the schema term (e.g. reprogrammedCellType) is aliasing a referenced schema (e.g. cellType). See example schema linked above.
- Schema is not versioned. Script would still work, but cannot register a versioned schema with an unversioned reference.
- Referenced schema not versioned (i.e. always points to the latest version). This script would still work, but cannot register an unversioned schema that has a versioned reference.