### PR TITLE
Add version to reprogrammedCellType and its reference

### DIFF
--- a/terms/experimentalData/reprogrammedCellType.json
+++ b/terms/experimentalData/reprogrammedCellType.json
@@ -1,10 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.reprogrammedCellType",
+    "$id": "sage.annotations-experimentalData.reprogrammedCellType-0.0.1",
     "description": "Cell type the specimen is modeling",
     "properties": {
         "reprogrammedCellType": {
-            "$ref": "sage.annotations-experimentalData.cellType"
+            "$ref": "sage.annotations-experimentalData.cellType-0.0.4"
         }
     }
 }


### PR DESCRIPTION
This has been a 'fun' term. Originally, the idea was to not version this term so that it would stay in sync with whatever cellType had, without having to change this term, as well. However, this reduces the ability to use versioning to control what values are available to a downstream consortia schema. While it is more finicky to have to update reprogrammedCellType any time cellType is updated, the added benefit outweighs the annoyance.

This PR adds:
- a version to reprogrammedCellType $id. Note that I put this at 0.0.1 since it had no version previously.
- the most recent version to the referenced cellType $id.