### PR TITLE
change waterpH key to string

### DIFF
--- a/terms/neuro/waterpH.json
+++ b/terms/neuro/waterpH.json
@@ -1,8 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-neuro.waterpH-0.0.1",
-  "description": "pH of water fed to the animal",
-  "type": "number",
-  "minimum": 0,
-  "maximum": 14
+  "$id": "sage.annotations-neuro.waterpH-0.0.2",
+  "description": "The pH of the water fed to the animal. Should be a number from 0-14 or a string specifying 'acidic', 'neutral', or 'basic'.",
+  "type": "string"
 }


### PR DESCRIPTION
This changes the metadata key type to string and updates the description to specify that the value should be entered as a number on the pH scale if known, or as acidic, neutral, or basic if exact pH is not known. These changes were requested by contributors and we don't annotate with this value so it doesn't need to be controlled.