### PR TITLE
Update age and age unit terms

### DIFF
--- a/terms/demographics/ageDeathUnits.json
+++ b/terms/demographics/ageDeathUnits.json
@@ -1,18 +1,23 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.ageDeathUnits-0.0.2",
+    "$id": "sage.annotations-demographics.ageDeathUnits-0.0.3",
     "type": "string",
     "description": "The death age unit of measure",
     "anyOf": [
         {
-            "const": "years",
-            "description": "Used for humans and primate models",
-            "source": "https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C29848"
+            "const": "days",
+            "description": "Age measured in days, a period of 24 hours.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C25301"
         },
         {
+            "const": "gestational weeks",
+            "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
+        }
+        {
             "const": "months",
-            "description": "Used for animal models",
-            "source": "https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C29846"
+            "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29846"
         },
         {
             "const": "PCW",
@@ -20,9 +25,14 @@
             "source": "https://embryology.med.unsw.edu.au/embryology/index.php/Timeline_human_development"
         },
         {
-            "const": "gestational weeks",
-            "description": "Used for humans",
-            "source": "https://ncim.nci.nih.gov/ncimbrowser/ConceptReport.jsp?dictionary=NCI%20Metathesaurus&code=CL1385889"
+            "const": "weeks",
+            "description": "Age measured in weeks, a period of 7 consecutive days.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29844"
+        },
+        {
+            "const": "years",
+            "description": "Age measured in years (approximately 365 days).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29848"
         }
     ]
 }

--- a/terms/demographics/ageDeathUnits.json
+++ b/terms/demographics/ageDeathUnits.json
@@ -13,7 +13,7 @@
             "const": "gestational weeks",
             "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
             "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
-        }
+        },
         {
             "const": "months",
             "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",

--- a/terms/experimentalData/ageAssessment.json
+++ b/terms/experimentalData/ageAssessment.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "sage.annotations-experimentalData.ageAssessment-0.0.1",
+  "description": "Age of clinical or behavioral assessment.",
+  "type": "number"
+}

--- a/terms/experimentalData/ageAssessmentUnits.json
+++ b/terms/experimentalData/ageAssessmentUnits.json
@@ -12,7 +12,7 @@
             "const": "gestational weeks",
             "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
             "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
-        }
+        },
         {
             "const": "months",
             "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",

--- a/terms/experimentalData/ageAssessmentUnits.json
+++ b/terms/experimentalData/ageAssessmentUnits.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "sage.annotations-experimentalData.ageAssessmentUnits-0.0.1",
+  "description": "Age of assessment units.",
+  "anyOf": [
+    {
+            "const": "days",
+            "description": "Age measured in days, a period of 24 hours.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C25301"
+        },
+        {
+            "const": "gestational weeks",
+            "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
+        }
+        {
+            "const": "months",
+            "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29846"
+        },
+        {
+            "const": "PCW",
+            "description": "Post-Conception Weeks",
+            "source": "https://embryology.med.unsw.edu.au/embryology/index.php/Timeline_human_development"
+        },
+        {
+            "const": "weeks",
+            "description": "Age measured in weeks, a period of 7 consecutive days.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29844"
+        },
+        {
+            "const": "years",
+            "description": "Age measured in years (approximately 365 days).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29848"
+        }
+    ]
+}

--- a/terms/experimentalData/samplingAgeUnits.json
+++ b/terms/experimentalData/samplingAgeUnits.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "sage.annotations-experimentalData.samplingAgeUnits-0.0.1",
+  "description": "Age at sampling units.",
+  "anyOf": [
+    {
+            "const": "days",
+            "description": "Age measured in days, a period of 24 hours.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C25301"
+        },
+        {
+            "const": "gestational weeks",
+            "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
+        }
+        {
+            "const": "months",
+            "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29846"
+        },
+        {
+            "const": "PCW",
+            "description": "Post-Conception Weeks",
+            "source": "https://embryology.med.unsw.edu.au/embryology/index.php/Timeline_human_development"
+        },
+        {
+            "const": "weeks",
+            "description": "Age measured in weeks, a period of 7 consecutive days.",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29844"
+        },
+        {
+            "const": "years",
+            "description": "Age measured in years (approximately 365 days).",
+            "source": "http://purl.obolibrary.org/obo/NCIT_C29848"
+        }
+    ]
+}

--- a/terms/experimentalData/samplingAgeUnits.json
+++ b/terms/experimentalData/samplingAgeUnits.json
@@ -12,7 +12,7 @@
             "const": "gestational weeks",
             "description": "Gestational age (written with both weeks and days, e.g. 39 weeks and 0 days) is calculated using the best obstetrical estimated due date (EDD) based on the following formula: Gestational Age = (280 - (EDD - Reference Date))/ 7. Note: Reference Date is the date on which you are trying to determine gestational age.",
             "source": "http://purl.obolibrary.org/obo/NCIT_C81253"
-        }
+        },
         {
             "const": "months",
             "description": "Age measured in calendar months (approximately 30 days or 4 weeks).",


### PR DESCRIPTION
This PR adds values to the ageDeathUnits term and creates new terms for ageAssessment, ageAssessmentUnits, and samplingAgeUnits. All three "age units" terms have identical values; we don't anticipate needing to add values frequently, but when we do we should try to add to all age unit terms at once. We decided this would be simpler than aliasing the new terms to ageDeathUnits, but can revisit in the future if desired.