### PR TITLE
add specimenIdSource definition and new chromosome value

### DIFF
--- a/terms/experimentalData/chromosome.json
+++ b/terms/experimentalData/chromosome.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.chromosome-0.0.2",
+  "$id": "sage.annotations-experimentalData.chromosome-0.0.3",
   "description": "A structure composed of a very long molecule of DNA and associated proteins (e.g. histones) that carries hereditary information; number or designation of the particular chromosome that the data is associated with.",
   "anyOf": [
     {
@@ -122,6 +122,11 @@
       "const": "Y",
       "description": "Chromosome Y",
       "source": "Sage Bionetworks"
+    },
+    {
+      "const": "mitochondrial",
+      "description": "A chromosome found in the mitochondrion of a eukaryotic cell.",
+      "source": "http://purl.obolibrary.org/obo/GO_0000262"
     }
   ]
 }

--- a/terms/experimentalData/specimenIdSource.json
+++ b/terms/experimentalData/specimenIdSource.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenIdSource-0.0.1",
-    "description": "",
+    "$id": "sage.annotations-experimentalData.specimenIdSource-0.0.2",
+    "description": "The repository or database to which a specimenID maps; or, the group or lab that generated the specimen. For cell culture studies, the commercial source or lab that generated the cells.",
     "type": "string"
 }
 


### PR DESCRIPTION
- added a definition for the specimenIdSource key, which was previously missing, to clarify what we are looking for in in vivo and in vitro studies
- added "mitochondrial" as a chromosome value