### PR TITLE
New terms for STARRSeq assay

### DIFF
--- a/terms/ngs/commercialSource.json
+++ b/terms/ngs/commercialSource.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "sage.annotations-ngs.commercialSource-0.0.1",
+    "description": "Nucleic or amino acids characterized that originate from a commercial source.",
+    "anyOf": [
+        {
+            "const": "Promega G1471",
+            "description": "Commercially available human genomic DNA distributed by Promega.",
+            "source": "https://www.promega.com/products/biochemicals-and-labware/nucleic-acids/human-genomic-dna/?catNum=G1521"
+        }
+    ]
+}
+

--- a/terms/ngs/libraryType.json
+++ b/terms/ngs/libraryType.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "sage.annotations-ngs.libraryType-0.0.1",
-  "description": "The type of library, in assays where samples are barcoded or hashed for multiplexing and each sample has multiple libraries amplified separately before pooled sequencing.",
+  "description": "The type of library, in assays where samples are barcoded or hashed for multiplexing or each sample has multiple libraries amplified separately before pooled sequencing.",
   "anyOf": [
     {
       "const": "ADT",
@@ -27,6 +27,11 @@
       "const": "LMO",
       "description": "Lipid-modified oligonucleotide sample barcode anchor.",
       "source": "https://doi.org/10.1038/s41592-019-0433-8"
+    },
+    {
+      "const": "plasmid DNA",
+      "description": "A small cellular inclusion consisting of a ring of DNA that is not in a chromosome but is capable of autonomous replication.",
+      "source": "http://purl.obolibrary.org/obo/NCIT_C754"
     }
   ]
 }

--- a/terms/ngs/libraryType.json
+++ b/terms/ngs/libraryType.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-ngs.libraryType-0.0.1",
+  "$id": "sage.annotations-ngs.libraryType-0.0.2",
   "description": "The type of library, in assays where samples are barcoded or hashed for multiplexing or each sample has multiple libraries amplified separately before pooled sequencing.",
   "anyOf": [
     {

--- a/terms/ngs/nucleicAcidSource.json
+++ b/terms/ngs/nucleicAcidSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.nucleicAcidSource-0.0.1",
+    "$id": "sage.annotations-ngs.nucleicAcidSource-0.0.2",
     "description": "",
     "anyOf": [
         {
@@ -37,6 +37,11 @@
             "const": "sorted nuclei",
             "description": "Sorted nuclei",
             "source": "Sage Bionetworks"
+        },
+        {
+        	"const": "cfDNA",
+        	"description": "Circulating cell-free DNA.",
+        	"source": "http://purl.obolibrary.org/obo/NCIT_C128274"
         }
     ]
 }


### PR DESCRIPTION
The PR: 

- Adds a new key commercialSource for nucleic or amino acids purchased from a private company. The goal here is to surface an accession number. 
- Modifies the definition of `libraryType` to be slightly more permissive. For this use case, this key is to also be applicable to plasmid insert ampliciation which is pooled but not _necessarily_ multiplexed.  
![Screen Shot 2021-07-19 at 10 59 07 AM](https://user-images.githubusercontent.com/40647130/126190390-5291aaad-6187-4266-84b6-91e4a2027a22.png)
- Adds value `plasmid DNA` to `libraryType`
- Adds value `cell-free DNA` to `nucleicAcidSource`
