### PR TITLE
Use absolute paths and add missing string types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ examples, but the general format for a new term should be like this:
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "anyOf": [
     {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ that are valid JSON Schema, such as the following:
 ```
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.1",
     "description": "Identifying string linked to a particular sample or specimen",
     "type": "string"
 }

--- a/schemas/testschema.json
+++ b/schemas/testschema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id":"sage.annotations-testschema.json-0.0.2",
+  "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-testschema.json-0.0.3",
   "properties": {
     "resourceType": {
       "$ref": "sage.annotations-sageCommunity.resourceType-0.0.1"

--- a/term-templates/template-boolean.json
+++ b/term-templates/template-boolean.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "boolean"
 }

--- a/term-templates/template-enum.json
+++ b/term-templates/template-enum.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "anyOf": [
     {

--- a/term-templates/template-number.json
+++ b/term-templates/template-number.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "number"
 }

--- a/term-templates/template-string.json
+++ b/term-templates/template-string.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-<MODULENAME>.<KEY>-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-<MODULENAME>.<KEY>-0.0.1",
   "description": "<DESCRIPTION OF THE KEY>",
   "type": "string",
   "minLength": 1,

--- a/terms/PsychENCODESpecific/grant.json
+++ b/terms/PsychENCODESpecific/grant.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sage.annotations-PsychENCODESpecific.grant-0.0.1",
+    "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-PsychENCODESpecific.grant-0.0.2",
     "description": "Grant number including activity code, institute code, and serial number (e.g. U01MH103392)",
     "type": "string",
     "anyOf": [

--- a/terms/PsychENCODESpecific/study.json
+++ b/terms/PsychENCODESpecific/study.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sage.annotations-PsychENCODESpecific.study-0.0.4",
+    "$id":"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-PsychENCODESpecific.study-0.0.5",
     "description": "Study",
     "type": "string",
     "anyOf": [

--- a/terms/analysis/alignmentMethod.json
+++ b/terms/analysis/alignmentMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.alignmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.alignmentMethod-0.0.2",
     "description": "DNA or RNA sequence alignment method",
+    "type": "string",
     "anyOf": [
         {
             "const": "Burrows-Wheeler technique",

--- a/terms/analysis/analysisType.json
+++ b/terms/analysis/analysisType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.analysisType-0.0.8",
-    "description": "",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.analysisType-0.0.9",
+    "description": "Type of analysis",
+    "type": "string",
     "anyOf": [
         {
             "const": "ANOVA",

--- a/terms/analysis/assemblyMethod.json
+++ b/terms/analysis/assemblyMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.assemblyMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.assemblyMethod-0.0.2",
     "description": "Algorithm used to build a reference genome from short read sequencing data.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Velvet",

--- a/terms/analysis/batchEffectCorrectionMethod.json
+++ b/terms/analysis/batchEffectCorrectionMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.batchEffectCorrectionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.batchEffectCorrectionMethod-0.0.2",
     "description": "Methods for identifying or correcting potential confounding variables in regression analyses.",
+    "type": "string",
     "anyOf": [
         {
             "const": "COMBAT",

--- a/terms/analysis/clusteringMethod.json
+++ b/terms/analysis/clusteringMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.clusteringMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.clusteringMethod-0.0.2",
     "description": "A method to identify groups of similar variables based on their data distribution.",
+    "type": "string",
     "anyOf": [
         {
             "const": "hierarchical clustering",

--- a/terms/analysis/differentialExpressionMethod.json
+++ b/terms/analysis/differentialExpressionMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.differentialExpressionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.differentialExpressionMethod-0.0.2",
     "description": "Method used to test for differentially expressed genes or isoforms.",
+    "type": "string",
     "anyOf": [
         {
             "const": "limma",

--- a/terms/analysis/enrichmentMethod.json
+++ b/terms/analysis/enrichmentMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.enrichmentMethod-0.0.1",
-    "description": "",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.enrichmentMethod-0.0.2",
+    "description": "Enrichment method.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Fisher's exact test",

--- a/terms/analysis/fdr.json
+++ b/terms/analysis/fdr.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.fdr-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.fdr-0.0.2",
     "type": "number",
     "description": "False discovery rate"
 }

--- a/terms/analysis/multipleTestingAdjustmentMethod.json
+++ b/terms/analysis/multipleTestingAdjustmentMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.multipleTestingAdjustmentMethod-0.0.2",
     "description": "Method used to control either family wise error rate, false discovery rate, or other measures of burden of false positives and false negatives when performing multiple statistical tests.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Benjamini Hochberg",

--- a/terms/analysis/peakCallingMethod.json
+++ b/terms/analysis/peakCallingMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.peakCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.peakCallingMethod-0.0.2",
     "description": "The algorithm used to identify protein-binding regions in a genome sequence from the data generated from a ChIP-sequencing or ChIP-chip experiment.",
+    "type": "string",
     "anyOf": [
         {
             "const": "MACS",

--- a/terms/analysis/somaticMutationCallingMethod.json
+++ b/terms/analysis/somaticMutationCallingMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.somaticMutationCallingMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.somaticMutationCallingMethod-0.0.2",
     "description": "Algorithm to call somatic mutations.",
+    "type": "string",
     "anyOf": [
         {
             "const": "VarDict",

--- a/terms/analysis/statisticalNetworkReconstructionMethod.json
+++ b/terms/analysis/statisticalNetworkReconstructionMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.1",
-    "description": "",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.statisticalNetworkReconstructionMethod-0.0.2",
+    "description": "Statistical network reconstruction method.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Weighted correlation network analysis",

--- a/terms/analysis/supervisedLearningMethod.json
+++ b/terms/analysis/supervisedLearningMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.supervisedLearningMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.supervisedLearningMethod-0.0.2",
     "description": "An algorithm to fit a model to make predictions of future outcomes based past data.",
+    "type": "string",
     "anyOf": [
         {
             "const": "penalized regression",

--- a/terms/analysis/transcriptQuantificationMethod.json
+++ b/terms/analysis/transcriptQuantificationMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.transcriptQuantificationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.transcriptQuantificationMethod-0.0.2",
     "description": "Method for quantifying abundance of transcript expression.",
+    "type": "string",
     "anyOf": [
         {
             "const": "kallisto",

--- a/terms/analysis/validationMethod.json
+++ b/terms/analysis/validationMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.validationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.validationMethod-0.0.2",
     "description": "Method to test targeted sequence level hypothesis.",
+    "type": "string",
     "anyOf": [
         {
             "const": "CRISPR-Cas9",

--- a/terms/analysis/visualizationMethod.json
+++ b/terms/analysis/visualizationMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-analysis.visualizationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-analysis.visualizationMethod-0.0.2",
     "description": "The format in which data is visually displayed.",
+    "type": "string",
     "anyOf": [
         {
             "const": "scatter plot",

--- a/terms/array/channel.json
+++ b/terms/array/channel.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-array.channel-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-array.channel-0.0.2",
     "description": "Fluorescent color labeling for an array",
+    "type": "string",
     "anyOf": [
         {
             "const": "Cy5",

--- a/terms/batch/arrayBatch.json
+++ b/terms/batch/arrayBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.arrayBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.arrayBatch-0.0.2",
     "type": "string",
     "description": "The hybridization batch the sample was in"
 }

--- a/terms/batch/batch.json
+++ b/terms/batch/batch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-batch.batch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.batch-0.0.2",
     "description": "Batch specimen was processed in",
     "type": "string"
 }

--- a/terms/batch/batchChannel.json
+++ b/terms/batch/batchChannel.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.batchChannel-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.batchChannel-0.0.2",
     "type": "string",
     "description": "TMT channel the sample is labeled with"
 }

--- a/terms/batch/dnaBatch.json
+++ b/terms/batch/dnaBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.dnaBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.dnaBatch-0.0.2",
     "type": "string",
     "description": "DNA isolation batch"
 }

--- a/terms/batch/libraryBatch.json
+++ b/terms/batch/libraryBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.libraryBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.libraryBatch-0.0.2",
     "type": "string",
     "description": "Batch library was prepared in"
 }

--- a/terms/batch/nanostringBatch.json
+++ b/terms/batch/nanostringBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.nanostringBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.nanostringBatch-0.0.2",
     "type": "string",
     "description": "The batch of samples run on a nanostring panel. Twelve samples can be processed together at once on a machine."
 }

--- a/terms/batch/rnaBatch.json
+++ b/terms/batch/rnaBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.rnaBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.rnaBatch-0.0.2",
     "type": "string",
     "description": "Batch in which RNA sample was isolated"
 }

--- a/terms/batch/sequencingBatch.json
+++ b/terms/batch/sequencingBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.sequencingBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.sequencingBatch-0.0.2",
     "type": "string",
     "description": "Batch library was sequenced in"
 }

--- a/terms/batch/transposaseBatch.json
+++ b/terms/batch/transposaseBatch.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-batch.transposaseBatch-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-batch.transposaseBatch-0.0.2",
     "type": "string",
     "description": "Transposition reaction batch"
 }

--- a/terms/cancer/cellSubType.json
+++ b/terms/cancer/cellSubType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.cellSubType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.cellSubType-0.0.2",
     "description": "This term is to be used when cell type is not specific enough, such as certain classes of T cells",
     "type": "string"
 }

--- a/terms/cancer/experimentalCondition.json
+++ b/terms/cancer/experimentalCondition.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.experimentalCondition-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalCondition-0.0.2",
     "description": "This describes the condition under which the data were collected, designed to be free form, extra things that do not fit in pre-defined terms",
     "type": "string"
 }

--- a/terms/cancer/experimentalTimePoint.json
+++ b/terms/cancer/experimentalTimePoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.experimentalTimePoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.experimentalTimePoint-0.0.2",
     "description": "Number describing time point at which data was collected",
     "type": "string"
 }

--- a/terms/cancer/genePerturbationTechnology.json
+++ b/terms/cancer/genePerturbationTechnology.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbationTechnology-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationTechnology-0.0.2",
     "description": "Technology used to perform gene perturbation",
+    "type": "string",
     "anyOf": [
         {
             "const": "RNAi",

--- a/terms/cancer/genePerturbationType.json
+++ b/terms/cancer/genePerturbationType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbationType-0.0.2",
     "description": "Specific way in which a single gene was perturbed in a sample",
+    "type": "string",
     "anyOf": [
         {
             "const": "overexpression",

--- a/terms/cancer/genePerturbed.json
+++ b/terms/cancer/genePerturbed.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.genePerturbed-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.genePerturbed-0.0.2",
     "description": "In the case of gene modulation, this describes the gene or genes that were modulated",
     "type": "string"
 }

--- a/terms/cancer/timePointUnit.json
+++ b/terms/cancer/timePointUnit.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.timePointUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.timePointUnit-0.0.2",
     "description": "For timed experiments this represents the unit of time measured",
+    "type": "string",
     "anyOf": [
         {
             "const": "hours",

--- a/terms/cancer/transplantationDonorTissue.json
+++ b/terms/cancer/transplantationDonorTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationDonorTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationDonorTissue-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/cancer/transplantationRecipientSpecies.json
+++ b/terms/cancer/transplantationRecipientSpecies.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationRecipientSpecies-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientSpecies-0.0.2",
     "description": "Species into which donor tissue was grown",
+    "type": "string",
     "anyOf": [
         {
             "const": "Human",

--- a/terms/cancer/transplantationRecipientTissue.json
+++ b/terms/cancer/transplantationRecipientTissue.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationRecipientTissue-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationRecipientTissue-0.0.2",
     "description": "In the case of a transplate, this describes the transplant destination",
     "type": "string"
 }

--- a/terms/cancer/transplantationType.json
+++ b/terms/cancer/transplantationType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.transplantationType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.transplantationType-0.0.2",
     "description": "Type of transplantation involved in the experiment, derived from MESH",
+    "type": "string",
     "anyOf": [
         {
             "const": "allograft",

--- a/terms/cancer/tumorType.json
+++ b/terms/cancer/tumorType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-cancer.tumorType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-cancer.tumorType-0.0.2",
     "description": "The type of cells that carcinoma arises from.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Cutaneous Neurofibroma",

--- a/terms/chem/chemicalDataType.json
+++ b/terms/chem/chemicalDataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDataType-0.0.2",
     "description": "The type of chemical data in the dataset.",
+    "type": "string",
     "anyOf": [
         {
             "const": "target",

--- a/terms/chem/chemicalDatabase.json
+++ b/terms/chem/chemicalDatabase.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalDatabase-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalDatabase-0.0.2",
     "description": "The chemical database from which the data were obtained.",
     "type": "string"
 }

--- a/terms/chem/chemicalStructure.json
+++ b/terms/chem/chemicalStructure.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.chemicalStructure-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.chemicalStructure-0.0.2",
     "description": "A linear representation of the chemical structure (SMILES, SMARTS, InChI, InChIKey, etc). Note the format using structureFormat.",
     "type": "string"
 }

--- a/terms/chem/fingerprintType.json
+++ b/terms/chem/fingerprintType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.fingerprintType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.fingerprintType-0.0.2",
     "description": "The type of chemical fingerprint used.",
+    "type": "string",
     "anyOf": [
         {
             "const": "standard",

--- a/terms/chem/structureFormat.json
+++ b/terms/chem/structureFormat.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-chem.structureFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-chem.structureFormat-0.0.2",
     "description": "The chemical structural representation used.",
+    "type": "string",
     "anyOf": [
         {
             "const": "SMILES",

--- a/terms/clinical/BMI.json
+++ b/terms/clinical/BMI.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.BMI-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.BMI-0.0.2",
     "type": "number",
     "description": "Body Mass Index"
 }

--- a/terms/clinical/Braak.json
+++ b/terms/clinical/Braak.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.Braak-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.Braak-0.0.2",
     "type": "integer",
     "minimum": 0,
     "maximum": 6,

--- a/terms/clinical/CDR.json
+++ b/terms/clinical/CDR.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.CDR-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.CDR-0.0.3",
     "type": "number",
     "description": "Clinical Dementia Rating"
 }

--- a/terms/clinical/CERAD.json
+++ b/terms/clinical/CERAD.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-clinical.CERAD-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.CERAD-0.0.2",
     "type": "integer",
     "minimum": 1,
     "maximum": 4,

--- a/terms/clinical/IQ.json
+++ b/terms/clinical/IQ.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.IQ-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.IQ-0.0.2",
     "type": "integer",
     "description": "IQ"
 }

--- a/terms/clinical/ageOnset.json
+++ b/terms/clinical/ageOnset.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.ageOnset-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.ageOnset-0.0.2",
     "type": "number",
     "description": "Age in years of the first symptoms"
 }

--- a/terms/clinical/apoeGenotype.json
+++ b/terms/clinical/apoeGenotype.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-clinical.apoeGenotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.apoeGenotype-0.0.2",
     "description": "Apolipoprotein E genotype",
+    "type": "string",
     "anyOf": [
         {
             "const": "22",

--- a/terms/clinical/causeDeath.json
+++ b/terms/clinical/causeDeath.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.causeDeath-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.causeDeath-0.0.2",
     "type": "string",
     "description": "The specific injury or disease that lead to death"
 }

--- a/terms/clinical/dementia.json
+++ b/terms/clinical/dementia.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.dementia-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.dementia-0.0.2",
     "type": "boolean",
     "description": "Is dementia present"
 }

--- a/terms/clinical/familyHistory.json
+++ b/terms/clinical/familyHistory.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.familyHistory-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.familyHistory-0.0.2",
     "type": "boolean",
     "description": "Is there a family history of the disorder/disease"
 }

--- a/terms/clinical/genotype.json
+++ b/terms/clinical/genotype.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.genotype-0.0.2",
     "type": "string",
     "description": "Genotype common name"
 }

--- a/terms/clinical/genotypeBackground.json
+++ b/terms/clinical/genotypeBackground.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.genotypeBackground-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.genotypeBackground-0.0.2",
     "type": "string",
     "description": "Genetic background of the model"
 }

--- a/terms/clinical/genotypeInferredAncestry.json
+++ b/terms/clinical/genotypeInferredAncestry.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.genotypeInferredAncestry-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.genotypeInferredAncestry-0.0.2",
     "type": "string",
     "description": "Ancestry inferred from the genotype"
 }

--- a/terms/clinical/litter.json
+++ b/terms/clinical/litter.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.litter-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.litter-0.0.2",
     "type": "string",
     "description": "Animal litter"
 }

--- a/terms/clinical/mannerDeath.json
+++ b/terms/clinical/mannerDeath.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.mannerDeath-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.mannerDeath-0.0.2",
     "type": "string",
     "description": "The determination of how the injury or disease lead to death",
     "anyOf": [

--- a/terms/clinical/matingID.json
+++ b/terms/clinical/matingID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.matingID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.matingID-0.0.2",
     "type": "string",
     "description": "Identifies the animals that were mated to produce the animal in question"
 }

--- a/terms/clinical/medRecordTox.json
+++ b/terms/clinical/medRecordTox.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.medRecordTox-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.medRecordTox-0.0.3",
     "type": "boolean",
     "description": "Is there a medical record toxicology report"
 }

--- a/terms/clinical/neuropathDescription.json
+++ b/terms/clinical/neuropathDescription.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.neuropathDescription-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.neuropathDescription-0.0.2",
     "type": "string",
     "description": "Description of neuropathology"
 }

--- a/terms/clinical/postmortemTox.json
+++ b/terms/clinical/postmortemTox.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.postmortemTox-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.postmortemTox-0.0.2",
     "type": "boolean",
     "description": "Were toxicology tests performed on post mortem tissue"
 }

--- a/terms/clinical/postmortemToxSource.json
+++ b/terms/clinical/postmortemToxSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.postmortemToxSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.postmortemToxSource-0.0.2",
     "type": "string",
     "description": "Tissues used for post mortem toxicology tests"
 }

--- a/terms/clinical/room.json
+++ b/terms/clinical/room.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.room-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.room-0.0.2",
     "type": "string",
     "description": "Room the animal was housed in"
 }

--- a/terms/clinical/sexChromosome.json
+++ b/terms/clinical/sexChromosome.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-clinical.sexChromosome-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-clinical.sexChromosome-0.0.2",
     "type": "string",
     "description": "Sex identified by SNP genotype (e.g XX, XY)"
 }

--- a/terms/compoundScreen/compoundDose.json
+++ b/terms/compoundScreen/compoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDose-0.0.2",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/compoundDoseRange.json
+++ b/terms/compoundScreen/compoundDoseRange.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDoseRange-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseRange-0.0.2",
     "description": "The minimum and maximum values of a treatment range; e.g. 1-25",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundDoseUnit.json
+++ b/terms/compoundScreen/compoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundDoseUnit-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/compoundName.json
+++ b/terms/compoundScreen/compoundName.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.compoundName-0.0.1",
-    "description": "",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.compoundName-0.0.2",
+    "description": "Name of the compound.",
+    "type": "string",
     "anyOf": [
         {
             "const": "PD0325901",

--- a/terms/compoundScreen/drugScreenType.json
+++ b/terms/compoundScreen/drugScreenType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.drugScreenType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.drugScreenType-0.0.2",
     "description": "String describing general class of drug screen",
+    "type": "string",
     "anyOf": [
         {
             "const": "singleMolecule",

--- a/terms/compoundScreen/secondCompoundDose.json
+++ b/terms/compoundScreen/secondCompoundDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDose-0.0.2",
     "description": "",
     "type": "number"
 }

--- a/terms/compoundScreen/secondCompoundDoseUnit.json
+++ b/terms/compoundScreen/secondCompoundDoseUnit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundDoseUnit-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/compoundScreen/secondCompoundName.json
+++ b/terms/compoundScreen/secondCompoundName.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-compoundScreen.secondCompoundName-0.0.1",
-    "description": "",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-compoundScreen.secondCompoundName-0.0.2",
+    "description": "Name of the compound.",
+    "type": "string",
     "anyOf": [
         {
             "const": "PD0325901",

--- a/terms/curatedData/curatedDataSource.json
+++ b/terms/curatedData/curatedDataSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.curatedDataSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataSource-0.0.2",
     "description": "The database or curator of the curated data.",
     "type": "string"
 }

--- a/terms/curatedData/curatedDataType.json
+++ b/terms/curatedData/curatedDataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.curatedDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.curatedDataType-0.0.2",
     "description": "The type of information being curated.",
+    "type": "string",
     "anyOf": [
         {
             "const": "reference sequence",

--- a/terms/curatedData/referenceSet.json
+++ b/terms/curatedData/referenceSet.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-curatedData.referenceSet-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-curatedData.referenceSet-0.0.3",
     "description": "A set of references (e.g., canonical assembled contigs) which defines a common coordinate space for comparing reference-aligned experimental data.",
+    "type": "string",
     "anyOf": [
         {
             "const": "1000 Genomes phase 3",

--- a/terms/demographics/ageDays.json
+++ b/terms/demographics/ageDays.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.ageDays-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.ageDays-0.0.2",
     "type": "number",
     "description": "Average age in days of the Drosophila individuals in the sample"
 }

--- a/terms/demographics/ageDeath.json
+++ b/terms/demographics/ageDeath.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.ageDeath-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.ageDeath-0.0.2",
     "type": "number",
     "description": "Age of death"
 }

--- a/terms/demographics/ageDeathUnits.json
+++ b/terms/demographics/ageDeathUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.ageDeathUnits-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.ageDeathUnits-0.0.4",
     "type": "string",
     "description": "The death age unit of measure",
     "anyOf": [

--- a/terms/demographics/dateBirth.json
+++ b/terms/demographics/dateBirth.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.dateBirth-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.dateBirth-0.0.2",
     "type": "string",
     "description": "Individual date of birth"
 }

--- a/terms/demographics/dateDeath.json
+++ b/terms/demographics/dateDeath.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.dateDeath-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.dateDeath-0.0.2",
     "type": "string",
     "description": "Individual date of death"
 }

--- a/terms/demographics/ethnicity.json
+++ b/terms/demographics/ethnicity.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.ethnicity-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.ethnicity-0.0.2",
     "type": "string",
     "description": "Ethnicity of the donor"
 }

--- a/terms/demographics/familialRelationship.json
+++ b/terms/demographics/familialRelationship.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-demographics.familialRelationship-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.familialRelationship-0.0.3",
     "type": "string",
     "description": "Family relationship between individuals in the study",
     "anyOf": [

--- a/terms/demographics/race.json
+++ b/terms/demographics/race.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.race-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.race-0.0.2",
     "type": "string",
     "description": "Race",
     "anyOf": [

--- a/terms/demographics/reportedGender.json
+++ b/terms/demographics/reportedGender.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.reportedGender-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.reportedGender-0.0.2",
     "type": "string",
     "description": "Gender as reported by the tissue bank",
     "anyOf": [

--- a/terms/demographics/yearsEducation.json
+++ b/terms/demographics/yearsEducation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-demographics.yearsEducation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-demographics.yearsEducation-0.0.2",
     "type": "number",
     "description": "Years of education starting with kindergarten"
 }

--- a/terms/dhart/caseNumber.json
+++ b/terms/dhart/caseNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.caseNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.caseNumber-0.0.2",
     "description": "This is the case number from the virtual repository",
     "type": "string"
 }

--- a/terms/dhart/collectionDate.json
+++ b/terms/dhart/collectionDate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.collectionDate-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.collectionDate-0.0.2",
     "description": "The date when this was collected",
     "type": "string"
 }

--- a/terms/dhart/projectNumber.json
+++ b/terms/dhart/projectNumber.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.projectNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.projectNumber-0.0.2",
     "description": "There are four projects on going in the spore. This describes for which one the data was collected.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Project 1",

--- a/terms/dhart/specimenQuantity.json
+++ b/terms/dhart/specimenQuantity.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.specimenQuantity-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.specimenQuantity-0.0.2",
     "description": "Currently unused, but could be used to describe how much specimen remains",
     "type": "string"
 }

--- a/terms/dhart/studySite.json
+++ b/terms/dhart/studySite.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-dhart.studySite-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-dhart.studySite-0.0.2",
     "description": "This describes the site where the specimen was collected",
     "type": "string"
 }

--- a/terms/experimentalData/MRItype.json
+++ b/terms/experimentalData/MRItype.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.MRItype-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.MRItype-0.0.2",
   "description": "The type of MRI assay performed.",
+  "type": "string",
   "anyOf": [
     {
       "const": "DTI",

--- a/terms/experimentalData/SentrixID.json
+++ b/terms/experimentalData/SentrixID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.SentrixID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.SentrixID-0.0.2",
     "description": "BeadChip ID in Illumina array-based assay",
     "type": "string"
 }

--- a/terms/experimentalData/SentrixRowColumn.json
+++ b/terms/experimentalData/SentrixRowColumn.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.SentrixRowColumn-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.SentrixRowColumn-0.0.2",
     "description": "Position of sample on BeadChip in Illumina array-based assay",
     "type": "string"
 }

--- a/terms/experimentalData/TMTType.json
+++ b/terms/experimentalData/TMTType.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.TMTType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.TMTType-0.0.2",
     "type": "string",
     "description": "Specifies how TMT reporter ions are quantified"
 }

--- a/terms/experimentalData/ageAssessment.json
+++ b/terms/experimentalData/ageAssessment.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.ageAssessment-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ageAssessment-0.0.2",
   "description": "Age of clinical or behavioral assessment.",
   "type": "number"
 }

--- a/terms/experimentalData/ageAssessmentUnits.json
+++ b/terms/experimentalData/ageAssessmentUnits.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.ageAssessmentUnits-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ageAssessmentUnits-0.0.2",
   "description": "Age of assessment units.",
+  "type": "string",
   "anyOf": [
     {
             "const": "days",

--- a/terms/experimentalData/assay.json
+++ b/terms/experimentalData/assay.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.assay-0.0.14",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assay-0.0.15",
     "description": "The technology used to generate the data in this file",
+    "type": "string",
     "anyOf": [
         {
             "const": "16SrRNAseq",

--- a/terms/experimentalData/assayTarget.json
+++ b/terms/experimentalData/assayTarget.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.assayTarget-0.0.5",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.assayTarget-0.0.6",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "ARID1B",

--- a/terms/experimentalData/batchSize.json
+++ b/terms/experimentalData/batchSize.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.batchSize-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.batchSize-0.0.2",
     "description": "Size of batch",
     "type": "number"
 }

--- a/terms/experimentalData/bindingDensity.json
+++ b/terms/experimentalData/bindingDensity.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bindingDensity-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bindingDensity-0.0.2",
   "type": "string",
   "description": "The number of optical features per square micron for each lane. (Definition is from https://www.nanostring.com/wp-content/uploads/2020/12/Gene_Expression_Data_Analysis_Guidelines.pdf)"
 }

--- a/terms/experimentalData/bindingDensity.json
+++ b/terms/experimentalData/bindingDensity.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.bindingDensity-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bindingDensity-0.0.1",
   "type": "string",
   "description": "The number of optical features per square micron for each lane. (Definition is from https://www.nanostring.com/wp-content/uploads/2020/12/Gene_Expression_Data_Analysis_Guidelines.pdf)"
 }

--- a/terms/experimentalData/bodyPart.json
+++ b/terms/experimentalData/bodyPart.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.bodyPart-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.bodyPart-0.0.2",
     "description": "Named areas of the body.",
+    "type": "string",
     "anyOf": [
         {
             "const": "head",

--- a/terms/experimentalData/brainWeight.json
+++ b/terms/experimentalData/brainWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.brainWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.brainWeight-0.0.2",
     "type": "number",
     "description": "Weight of brain in grams"
 }

--- a/terms/experimentalData/cellLine.json
+++ b/terms/experimentalData/cellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLine-0.0.2",
     "description": "Identifying string linked to a particular cell line",
     "type": "string"
 }

--- a/terms/experimentalData/cellLineSource.json
+++ b/terms/experimentalData/cellLineSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellLineSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellLineSource-0.0.2",
     "description": "Identifying source of cell line, such as ATCC site",
     "type": "string"
 }

--- a/terms/experimentalData/cellType.json
+++ b/terms/experimentalData/cellType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.cellType-0.0.7",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.8",
     "description": "A cell type is a distinct morphological or functional form of cell.",
+    "type": "string",
     "anyOf": [
         {
             "const": "A549",

--- a/terms/experimentalData/chromosome.json
+++ b/terms/experimentalData/chromosome.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.chromosome-0.0.3",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.chromosome-0.0.4",
   "description": "A structure composed of a very long molecule of DNA and associated proteins (e.g. histones) that carries hereditary information; number or designation of the particular chromosome that the data is associated with.",
+  "type": "string",
   "anyOf": [
     {
       "const": "1",

--- a/terms/experimentalData/contrastAgent.json
+++ b/terms/experimentalData/contrastAgent.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.contrastAgent-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.contrastAgent-0.0.2",
   "description": "Substance administered during an imaging procedure that allows delineation of internal structures.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/controlType.json
+++ b/terms/experimentalData/controlType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.controlType-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.controlType-0.0.4",
     "description": "Control samples suitable for normalization and batch correction",
+    "type": "string",
     "anyOf": [
         {
             "const": "AIBL pool",

--- a/terms/experimentalData/dataSubtype.json
+++ b/terms/experimentalData/dataSubtype.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.dataSubtype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataSubtype-0.0.2",
     "description": "Further qualification of dataType, which may be used to indicate the state of processing of the data, aggregation of the data, or presence of metadata.",
+    "type": "string",
     "anyOf": [
         {
             "const": "normalized",

--- a/terms/experimentalData/dataType.json
+++ b/terms/experimentalData/dataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.dataType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.dataType-0.0.3",
     "description": "Types of input/output data in bioinformatics pipelines",
+    "type": "string",
     "anyOf": [
         {
             "const": "Volume",

--- a/terms/experimentalData/diagnosis.json
+++ b/terms/experimentalData/diagnosis.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.diagnosis-0.0.8",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosis-0.0.9",
     "description": "A diagnosis is the result of a medical investigation to identify a disorder from its signs and symptoms.",
+    "type": "string",
     "anyOf": [
         {
             "const": "AD-DS",

--- a/terms/experimentalData/diagnosisCriteria.json
+++ b/terms/experimentalData/diagnosisCriteria.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.diagnosisCriteria-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisCriteria-0.0.2",
   "type": "string",
   "description": "If a diagnosis is provided, the criteria it is based on"
 }

--- a/terms/experimentalData/diagnosisDetail.json
+++ b/terms/experimentalData/diagnosisDetail.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.diagnosisDetail-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.diagnosisDetail-0.0.2",
   "type": "string",
   "description": "Subgroup of diagnosis (DSM or ICD code)"
 }

--- a/terms/experimentalData/differentiationMethod.json
+++ b/terms/experimentalData/differentiationMethod.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.differentiationMethod-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.differentiationMethod-0.0.2",
   "description": "The general strategy by which a reprogrammed or pluripotent cell is differentiated into a target cell.",
+  "type": "string",
   "anyOf": [
         {
             "const": "directed differentiation",

--- a/terms/experimentalData/exclude.json
+++ b/terms/experimentalData/exclude.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.exclude-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.exclude-0.0.2",
     "description": "Boolean flag indicating whether or not sample should be excluded from analysis",
     "type": "boolean"
 }

--- a/terms/experimentalData/excludeReason.json
+++ b/terms/experimentalData/excludeReason.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.excludeReason-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.excludeReason-0.0.2",
     "description": "Reason why a sample should be excluded from analysis",
     "type": "string"
 }

--- a/terms/experimentalData/failedQC.json
+++ b/terms/experimentalData/failedQC.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.failedQC-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.failedQC-0.0.3",
     "description": "Boolean flag indicating whether the sample or data failed QC checks",
     "type": "boolean"
 }

--- a/terms/experimentalData/fastingState.json
+++ b/terms/experimentalData/fastingState.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.fastingState-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.fastingState-0.0.2",
   "type": "boolean",
   "description": "Was individual fasting when sample was taken (true/false)?"
 }

--- a/terms/experimentalData/fieldStrength.json
+++ b/terms/experimentalData/fieldStrength.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.fieldStrength-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.fieldStrength-0.0.2",
   "description": "The intensity of an electric, magnetic, or other field. Value should include unit of measurement.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/fragmentation.json
+++ b/terms/experimentalData/fragmentation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.fragmentation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.fragmentation-0.0.2",
     "type": "string",
     "description": "Specifies the mode by which MS2 and MS3 ions are generated"
 }

--- a/terms/experimentalData/gDNAconc.json
+++ b/terms/experimentalData/gDNAconc.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.gDNAconc-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.gDNAconc-0.0.2",
     "type": "number",
     "description": "gDNA Concentration in ng"
 }

--- a/terms/experimentalData/geneRLF.json
+++ b/terms/experimentalData/geneRLF.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.geneRLF-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.geneRLF-0.0.2",
     "type": "string",
     "description": "Reporter Library File (RLF) used to associate gene names with counts specified by the user in the Cartridge Definition File (https://www.genetics.pitt.edu/sites/default/files/pdfs/nCounter_Gene_Expression_Data_Analysis_Guidelines.pdf)"
 }

--- a/terms/experimentalData/individualID.json
+++ b/terms/experimentalData/individualID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.individualID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualID-0.0.2",
     "description": "Identifying string linked to the individual or animal being studied",
     "type": "string"
 }

--- a/terms/experimentalData/individualIdSource.json
+++ b/terms/experimentalData/individualIdSource.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.individualIdSource-0.0.10",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.individualIdSource-0.0.11",
     "description": "Database or repository to which individual ID maps",
+    "type": "string",
     "anyOf": [
         {
             "const": "ABN",

--- a/terms/experimentalData/ionMode.json
+++ b/terms/experimentalData/ionMode.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.ionMode-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ionMode-0.0.2",
     "description": "Ionization polarity (positive, negative, polar)",
     "type": "string"
 }

--- a/terms/experimentalData/isAssayControl.json
+++ b/terms/experimentalData/isAssayControl.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.isAssayControl-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isAssayControl-0.0.2",
   "description": "Boolean flag indicating whether or not a specimen is a technical or assay control. Examples include study pools or reference pools, blanks, or internal standards.",
   "type": "boolean"
 }

--- a/terms/experimentalData/isCellLine.json
+++ b/terms/experimentalData/isCellLine.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isCellLine-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isCellLine-0.0.2",
     "description": "Boolean flag indicating whether or not sample source is a cell line",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiIndividual.json
+++ b/terms/experimentalData/isMultiIndividual.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isMultiIndividual-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiIndividual-0.0.2",
     "description": "Boolean flag indicating whether or not a file has data for multiple individuals",
     "type": "boolean"
 }

--- a/terms/experimentalData/isMultiSpecimen.json
+++ b/terms/experimentalData/isMultiSpecimen.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isMultiSpecimen-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isMultiSpecimen-0.0.2",
     "description": "Boolean flag indicating whether or not a file has data for multiple specimens",
     "type": "boolean"
 }

--- a/terms/experimentalData/isPostMortem.json
+++ b/terms/experimentalData/isPostMortem.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.isPostMortem-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isPostMortem-0.0.2",
     "type": "boolean",
     "description": "Was the sample taken after death (true/false)"
 }

--- a/terms/experimentalData/isPrimaryCell.json
+++ b/terms/experimentalData/isPrimaryCell.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.isPrimaryCell-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.isPrimaryCell-0.0.2",
     "description": "Boolean flag indicating whether or not cellType is primary, defined as 'A cell taken directly from a living organism, which is not immortalized'.",
     "type": "boolean"
 }

--- a/terms/experimentalData/lambdaDNAconc.json
+++ b/terms/experimentalData/lambdaDNAconc.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.lambdaDNAconc-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.lambdaDNAconc-0.0.2",
     "type": "number",
     "description": "Lambda DNA spike-in concentration in ng"
 }

--- a/terms/experimentalData/ligand.json
+++ b/terms/experimentalData/ligand.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.ligand-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.ligand-0.0.2",
   "description": "An ion, molecule or molecular group that binds to a substance to form a larger complex.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/metaboliteType.json
+++ b/terms/experimentalData/metaboliteType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.metaboliteType-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metaboliteType-0.0.4",
     "description": "Class of metabolite.",
+    "type": "string",
     "anyOf": [
         {
             "const": "acylcarnitines",

--- a/terms/experimentalData/metadataType.json
+++ b/terms/experimentalData/metadataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.metadataType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.metadataType-0.0.3",
     "description": "For files of dataSubtype: metadata, a description of the type of metadata in the file.",
+    "type": "string",
     "anyOf": [
         {
             "const": "analytical covariates",

--- a/terms/experimentalData/modelSystemType.json
+++ b/terms/experimentalData/modelSystemType.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.modelSystemType-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.modelSystemType-0.0.2",
   "description": "Type of model system.",
+  "type": "string",
   "anyOf": [
         {
             "const": "animal",

--- a/terms/experimentalData/multiconsensusStudyFileID.json
+++ b/terms/experimentalData/multiconsensusStudyFileID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.multiconsensusStudyFileID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.multiconsensusStudyFileID-0.0.2",
     "type": "string",
     "description": "F-number assigned by Termo Proteome Discoverer software to different batches (plexes) of RAW (direct Thermo mass spectrometer output) files (F01, F02, etc.)"
 }

--- a/terms/experimentalData/nFemale.json
+++ b/terms/experimentalData/nFemale.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.nFemale-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.nFemale-0.0.2",
     "type": "integer",
     "description": "Number of female individuals in a pooled Drosophila sample"
 }

--- a/terms/experimentalData/nIndividuals.json
+++ b/terms/experimentalData/nIndividuals.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.nIndividuals-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.nIndividuals-0.0.2",
     "type": "integer",
     "description": "Number of individuals in a pooled Drosophila sample"
 }

--- a/terms/experimentalData/nMale.json
+++ b/terms/experimentalData/nMale.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.nMale-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.nMale-0.0.2",
     "type": "integer",
     "description": "Number of male individuals in a pooled Drosophila sample"
 }

--- a/terms/experimentalData/numberCells.json
+++ b/terms/experimentalData/numberCells.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.numberCells-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.numberCells-0.0.2",
     "type": "integer",
     "description": "Number of cells or nuclei sequenced"
 }

--- a/terms/experimentalData/organ.json
+++ b/terms/experimentalData/organ.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.organ-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organ-0.0.4",
     "description": "A unique macroscopic (gross) anatomic structure that performs specific functions. It is composed of various tissues. An organ is part of an anatomic system or a body region.",
+    "type": "string",
     "anyOf": [
         {
             "const": "blood",

--- a/terms/experimentalData/organWeight.json
+++ b/terms/experimentalData/organWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.organWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.organWeight-0.0.2",
     "type": "number",
     "description": "Post-mortem weight of organ (in grams)"
 }

--- a/terms/experimentalData/otherMedicalDx.json
+++ b/terms/experimentalData/otherMedicalDx.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-experimentalData.otherMedicalDx-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.otherMedicalDx-0.0.2",
   "type": "string",
   "description": "Other medical diagnoses unrelated to the primary study indication"
 }

--- a/terms/experimentalData/passage.json
+++ b/terms/experimentalData/passage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.passage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.passage-0.0.2",
     "type": "integer",
     "description": "Number of times a cell culture has been subcultured"
 }

--- a/terms/experimentalData/pcrCycles.json
+++ b/terms/experimentalData/pcrCycles.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.pcrCycles-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.pcrCycles-0.0.2",
     "type": "integer",
     "description": "Number of PCR cycles to amplify transposased DNA fragments"
 }

--- a/terms/experimentalData/plateCoating.json
+++ b/terms/experimentalData/plateCoating.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.plateCoating-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.plateCoating-0.0.2",
   "description": "Matrix coating applied to tissue culture plates.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/platform.json
+++ b/terms/experimentalData/platform.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.platform-0.0.15",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platform-0.0.16",
     "description": "The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Affy5.0",

--- a/terms/experimentalData/platformLocation.json
+++ b/terms/experimentalData/platformLocation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.platformLocation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.platformLocation-0.0.2",
     "description": "Laboratory where data generation platform was located",
     "type": "string"
 }

--- a/terms/experimentalData/reprogrammedCellType.json
+++ b/terms/experimentalData/reprogrammedCellType.json
@@ -1,10 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.reprogrammedCellType-0.0.4",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.reprogrammedCellType-0.0.5",
     "description": "Cell type the specimen is modeling",
     "properties": {
         "reprogrammedCellType": {
-            "$ref": "sage.annotations-experimentalData.cellType-0.0.7"
+            "$ref": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.8"
         }
     }
 }

--- a/terms/experimentalData/reprogrammingMethod.json
+++ b/terms/experimentalData/reprogrammingMethod.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.reprogrammingMethod-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.reprogrammingMethod-0.0.2",
   "description": "The method by which source cells were reprogrammed into pluripotent stem cells.",
+  "type": "string",
   "anyOf": [
         {
             "const": "CytoTune iPS 2.0 Sendai Reprogramming Kit",

--- a/terms/experimentalData/resolution.json
+++ b/terms/experimentalData/resolution.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.resolution-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.resolution-0.0.2",
     "type": "number",
     "description": "Minimum nominal mass-over-charge (m/z) difference detectable"
 }

--- a/terms/experimentalData/sampleStatus.json
+++ b/terms/experimentalData/sampleStatus.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.sampleStatus-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sampleStatus-0.0.2",
     "description": "Conditions under which sample is kept",
+    "type": "string",
     "anyOf": [
         {
             "const": "formalin-fixed",

--- a/terms/experimentalData/samplingAge.json
+++ b/terms/experimentalData/samplingAge.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.samplingAge-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.samplingAge-0.0.2",
     "type": "number",
     "description": "Age of the individual when the sample was taken"
 }

--- a/terms/experimentalData/samplingAgeUnits.json
+++ b/terms/experimentalData/samplingAgeUnits.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.samplingAgeUnits-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.samplingAgeUnits-0.0.2",
   "description": "Age at sampling units.",
+  "type": "string",
   "anyOf": [
     {
             "const": "days",

--- a/terms/experimentalData/scanID.json
+++ b/terms/experimentalData/scanID.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.scanID-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.scanID-0.0.2",
   "description": "The ID of a sample, specimen, or individual in a scan or imaging file.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/sex.json
+++ b/terms/experimentalData/sex.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.sex-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sex-0.0.2",
     "description": "Sex assigned at birth, or by sequencing",
+    "type": "string",
     "anyOf": [
         {
             "const": "male",

--- a/terms/experimentalData/sourceCell.json
+++ b/terms/experimentalData/sourceCell.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "sage.annotations-experimentalData.sourceCell-0.0.1",
   "description": "Initial cell type the target cell was derived from, before reprogramming or differentiation.",
+  "type": "string",
   "anyOf": [
         {
             "const": "astrocytes",

--- a/terms/experimentalData/sourceCell.json
+++ b/terms/experimentalData/sourceCell.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.sourceCell-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.sourceCell-0.0.2",
   "description": "Initial cell type the target cell was derived from, before reprogramming or differentiation.",
   "type": "string",
   "anyOf": [

--- a/terms/experimentalData/species.json
+++ b/terms/experimentalData/species.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.species-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.species-0.0.2",
     "description": "The name of a species (typically a taxonomic group) of organism.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Human",

--- a/terms/experimentalData/specimenID.json
+++ b/terms/experimentalData/specimenID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenID-0.0.2",
     "description": "Identifying string linked to a particular sample or specimen",
     "type": "string"
 }

--- a/terms/experimentalData/specimenIdSource.json
+++ b/terms/experimentalData/specimenIdSource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.specimenIdSource-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.specimenIdSource-0.0.3",
     "description": "The repository or database to which a specimenID maps; or, the group or lab that generated the specimen. For cell culture studies, the commercial source or lab that generated the cells.",
     "type": "string"
 }

--- a/terms/experimentalData/spectrometerFrequency.json
+++ b/terms/experimentalData/spectrometerFrequency.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.spectrometerFrequency-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.spectrometerFrequency-0.0.2",
   "description": "The frequency at which a spectrometer causes hydrogen atoms to resonate (in MHz).",
   "type": "number"
 }

--- a/terms/experimentalData/stemCellBaseMedium.json
+++ b/terms/experimentalData/stemCellBaseMedium.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-experimentalData.stemCellBaseMedium-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.stemCellBaseMedium-0.0.2",
   "description": "Culture medium that stem cells are grown in during differentiation.",
   "type": "string",
   "minLength": 1,

--- a/terms/experimentalData/temperature.json
+++ b/terms/experimentalData/temperature.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.temperature-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.temperature-0.0.2",
     "type": "number",
     "description": "Temperature in Celsius (C) relevant to specimen or experimental condition"
 }

--- a/terms/experimentalData/terminalDifferentiationPoint.json
+++ b/terms/experimentalData/terminalDifferentiationPoint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.terminalDifferentiationPoint-0.0.2",
     "description": "The terminal differentiation point (TD) of a cell in days.",
     "type": "string"
 }

--- a/terms/experimentalData/tissue.json
+++ b/terms/experimentalData/tissue.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-experimentalData.tissue-0.0.8",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissue-0.0.9",
     "description": "A tissue is a mereologically maximal collection of cells that together perform physiological function.",
+    "type": "string",
     "anyOf": [
         {
             "const": "amygdala",

--- a/terms/experimentalData/tissueVolume.json
+++ b/terms/experimentalData/tissueVolume.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.tissueVolume-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissueVolume-0.0.2",
     "type": "number",
     "description": "Volume of tissue sample in microliters"
 }

--- a/terms/experimentalData/tissueWeight.json
+++ b/terms/experimentalData/tissueWeight.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.tissueWeight-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.tissueWeight-0.0.2",
     "type": "number",
     "description": "Mass of tissue specimen in mg"
 }

--- a/terms/experimentalData/totalReads.json
+++ b/terms/experimentalData/totalReads.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.totalReads-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.totalReads-0.0.2",
     "type": "number",
     "description": "Total number of sequencing reads from a library"
 }

--- a/terms/experimentalData/visitNumber.json
+++ b/terms/experimentalData/visitNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-experimentalData.visitNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.visitNumber-0.0.2",
     "type": "number",
     "description": "For clinical trials or longitudinal studies, the visit number when the sample was collected"
 }

--- a/terms/genie/cBioFileFormat.json
+++ b/terms/genie/cBioFileFormat.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.cBioFileFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.cBioFileFormat-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "clinical",

--- a/terms/genie/center.json
+++ b/terms/genie/center.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.center-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.center-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "NKI",

--- a/terms/genie/fileStage.json
+++ b/terms/genie/fileStage.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-genie.fileStage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-genie.fileStage-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "staging",

--- a/terms/immunoAssays/antibody.json
+++ b/terms/immunoAssays/antibody.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibody-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibody-0.0.2",
     "description": "An immunoglobulin complex that is secreted into extracellular space and found in mucosal areas or other tissues or circulating in the blood or lymph",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyAmount.json
+++ b/terms/immunoAssays/antibodyAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmount-0.0.2",
     "description": "Amount of antibody used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyAmountUnits.json
+++ b/terms/immunoAssays/antibodyAmountUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyAmountUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyAmountUnits-0.0.2",
     "description": "Units of measure for the amount of antibody used for an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyConcentration.json
+++ b/terms/immunoAssays/antibodyConcentration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyConcentration-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentration-0.0.2",
     "description": "Concentration of antibody used in an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/antibodyConcentrationUnits.json
+++ b/terms/immunoAssays/antibodyConcentrationUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyConcentrationUnits-0.0.2",
     "description": "Units of measure for the concentration of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyDilution.json
+++ b/terms/immunoAssays/antibodyDilution.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyDilution-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyDilution-0.0.2",
     "description": "Ratio of antibody used in an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/antibodyOrder.json
+++ b/terms/immunoAssays/antibodyOrder.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.antibodyOrder-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.antibodyOrder-0.0.3",
     "description": "For ELISA assays, specifies whether the antibody was used as the primary or secondary antibody",
     "source": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5775980/",
     "type": "string",

--- a/terms/immunoAssays/bindingMolecule.json
+++ b/terms/immunoAssays/bindingMolecule.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.bindingMolecule-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.bindingMolecule-0.0.2",
     "type": "string",
     "description": "The binding molecule used in the assay"
 }

--- a/terms/immunoAssays/catalogNumber.json
+++ b/terms/immunoAssays/catalogNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.catalogNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.catalogNumber-0.0.2",
     "description": "The identifier assigned to a product, usually in the list of products published by a reseller or manufacturer",
     "type": "string"
 }

--- a/terms/immunoAssays/chromatinAmount.json
+++ b/terms/immunoAssays/chromatinAmount.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.chromatinAmount-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.chromatinAmount-0.0.2",
     "description": "Amount in ug of chromatin used for an assay",
     "type": "number"
 }

--- a/terms/immunoAssays/chromatinAmountUnits.json
+++ b/terms/immunoAssays/chromatinAmountUnits.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.chromatinAmountUnits-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.chromatinAmountUnits-0.0.2",
     "description": "Units of measure for the amount of chromatin used for an assay",
     "type": "string"
 }

--- a/terms/immunoAssays/elisaType.json
+++ b/terms/immunoAssays/elisaType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.elisaType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.elisaType-0.0.2",
     "description": "Type of ELISA assay",
+    "type": "string",
     "anyOf": [
         {
             "const": "direct",

--- a/terms/immunoAssays/fluorophore.json
+++ b/terms/immunoAssays/fluorophore.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.fluorophore-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.fluorophore-0.0.3",
     "description": "A fluorophore is a component of a molecule which causes a molecule to be fluorescent.",
     "type": "string"
 }

--- a/terms/immunoAssays/lotNumber.json
+++ b/terms/immunoAssays/lotNumber.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.lotNumber-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.lotNumber-0.0.2",
     "description": "A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch",
     "type": "string"
 }

--- a/terms/immunoAssays/vendor.json
+++ b/terms/immunoAssays/vendor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-immunoAssays.vendor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-immunoAssays.vendor-0.0.2",
     "description": "Commercial or institutional source of a component used in an assay",
     "type": "string"
 }

--- a/terms/manifestKeys/filename.json
+++ b/terms/manifestKeys/filename.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-manifestKeys.filename-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-manifestKeys.filename-0.0.2",
   "description": "The name of a file.",
   "type": "string",
   "minLength": 1,

--- a/terms/manifestKeys/parent.json
+++ b/terms/manifestKeys/parent.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-manifestKeys.parent-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-manifestKeys.parent-0.0.2",
     "type": "string",
     "description": "Synapse ID of the folder that data will be uploaded to"
 }

--- a/terms/manifestKeys/path.json
+++ b/terms/manifestKeys/path.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-manifestKeys.path-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-manifestKeys.path-0.0.2",
     "type": "string",
     "description": "File path where data files that will be uploaded are stored"
 }

--- a/terms/network/networkEdgeType.json
+++ b/terms/network/networkEdgeType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-network.networkEdgeType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-network.networkEdgeType-0.0.2",
     "description": "Method used to derive the edge in a network",
+    "type": "string",
     "anyOf": [
         {
             "const": "protein-protein interaction",

--- a/terms/neuro/BrodmannArea.json
+++ b/terms/neuro/BrodmannArea.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.BrodmannArea-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.BrodmannArea-0.0.2",
     "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture",
     "type": "string"
 }

--- a/terms/neuro/PMI.json
+++ b/terms/neuro/PMI.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.PMI-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.PMI-0.0.3",
     "description": "Post-mortem interval",
     "type": "string"
 }

--- a/terms/neuro/PMICertain.json
+++ b/terms/neuro/PMICertain.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-neuro.PMICertain-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.PMICertain-0.0.2",
     "type": "boolean",
     "description": "Is PMI certain, i.e. is time of death known (true/false)"
 }

--- a/terms/neuro/bedding.json
+++ b/terms/neuro/bedding.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.bedding-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.bedding-0.0.3",
     "description": "Rodent bedding material",
+    "type": "string",
     "anyOf": [
         {
             "const": "Alpha-dri",

--- a/terms/neuro/fileSubFormat.json
+++ b/terms/neuro/fileSubFormat.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.fileSubFormat-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.fileSubFormat-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "TranscriptomeSAM",

--- a/terms/neuro/grant.json
+++ b/terms/neuro/grant.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.grant-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.grant-0.0.2",
     "description": "Grant number including activity code, institute code, and serial number (e.g. U01MH103392)",
     "type": "string"
 }

--- a/terms/neuro/hemisphere.json
+++ b/terms/neuro/hemisphere.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.hemisphere-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.hemisphere-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "left",

--- a/terms/neuro/isConsortiumAnalysis.json
+++ b/terms/neuro/isConsortiumAnalysis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.isConsortiumAnalysis-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isConsortiumAnalysis-0.0.2",
     "description": "Collaborative consortium analysis",
     "type": "boolean"
 }

--- a/terms/neuro/isModelSystem.json
+++ b/terms/neuro/isModelSystem.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.isModelSystem-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.isModelSystem-0.0.2",
     "description": "",
     "type": "boolean"
 }

--- a/terms/neuro/modelSystemName.json
+++ b/terms/neuro/modelSystemName.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.modelSystemName-0.0.5",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemName-0.0.6",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "3xTg-AD",

--- a/terms/neuro/modelSystemStrainNomenclature.json
+++ b/terms/neuro/modelSystemStrainNomenclature.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.modelSystemStrainNomenclature-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.modelSystemStrainNomenclature-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "B6.Cg-Tg(APPswe,PSEN1dE9)85Dbo/Mmjax",

--- a/terms/neuro/pH.json
+++ b/terms/neuro/pH.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.pH-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.pH-0.0.3",
     "description": "A scale used to specify the acidity or basicity of an aqueous or other liquid solution",
     "type": "string"
 }

--- a/terms/neuro/study.json
+++ b/terms/neuro/study.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.study-0.0.29",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.study-0.0.30",
     "description": "Study",
+    "type": "string",
     "anyOf": [
         {
             "const": "3Dchromatin",

--- a/terms/neuro/treatmentDose.json
+++ b/terms/neuro/treatmentDose.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.treatmentDose-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentDose-0.0.2",
     "description": "Dose of treatment used, including units and timeframe",
     "type": "string"
 }

--- a/terms/neuro/treatmentDuration.json
+++ b/terms/neuro/treatmentDuration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-neuro.treatmentDuration-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentDuration-0.0.2",
   "description": "Planned or actual duration of any experimental or clinical treatment.",
   "type": "string",
   "minLength": 1,

--- a/terms/neuro/treatmentType.json
+++ b/terms/neuro/treatmentType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neuro.treatmentType-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.treatmentType-0.0.3",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "haloperidol",

--- a/terms/neuro/waterpH.json
+++ b/terms/neuro/waterpH.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-neuro.waterpH-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neuro.waterpH-0.0.2",
   "description": "pH of water fed to the animal",
   "type": "number",
   "minimum": 0,

--- a/terms/neurofibromatosis/nf1Genotype.json
+++ b/terms/neurofibromatosis/nf1Genotype.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.nf1Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf1Genotype-0.0.2",
     "description": "Genotype of NF1 gene, if known",
+    "type": "string",
     "anyOf": [
         {
             "const": "-/-",

--- a/terms/neurofibromatosis/nf2Genotype.json
+++ b/terms/neurofibromatosis/nf2Genotype.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.nf2Genotype-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.nf2Genotype-0.0.2",
     "description": "Genotype of NF2 gene, if known",
+    "type": "string",
     "anyOf": [
         {
             "const": "-/-",

--- a/terms/neurofibromatosis/reportMilestone.json
+++ b/terms/neurofibromatosis/reportMilestone.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-neurofibromatosis.reportMilestone-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-neurofibromatosis.reportMilestone-0.0.2",
     "description": "This key represents the milestone for which the report was submitted, a number representing number of months.",
     "type": "integer"
 }

--- a/terms/ngs/commercialSource.json
+++ b/terms/ngs/commercialSource.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.commercialSource-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.commercialSource-0.0.2",
     "description": "Nucleic or amino acids characterized that originate from a commercial source.",
+    "type": "string",
     "anyOf": [
         {
             "const": "Promega G1471",

--- a/terms/ngs/directionalBSseqLibrary.json
+++ b/terms/ngs/directionalBSseqLibrary.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "sage.annotations-ngs.directionalBSseqLibrary-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.directionalBSseqLibrary-0.0.2",
   "description": "Indicates whether or not the bisulfiteSeq library is directional",
   "type": "boolean"
 }

--- a/terms/ngs/dissociationMethod.json
+++ b/terms/ngs/dissociationMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.dissociationMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.dissociationMethod-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": " 10x_v2",

--- a/terms/ngs/dnaExtractionMethod.json
+++ b/terms/ngs/dnaExtractionMethod.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.dnaExtractionMethod-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.dnaExtractionMethod-0.0.2",
     "description": "The general strategy by which the DNA was extracted",
     "type": "string"
 }

--- a/terms/ngs/isStranded.json
+++ b/terms/ngs/isStranded.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.isStranded-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.isStranded-0.0.2",
     "description": "Whether or not the library is stranded.",
     "type": "boolean"
 }

--- a/terms/ngs/libraryID.json
+++ b/terms/ngs/libraryID.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-ngs.libraryID-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryID-0.0.2",
     "type": "string",
     "description": "Library ID as provided by the lab"
 }

--- a/terms/ngs/libraryPrep.json
+++ b/terms/ngs/libraryPrep.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.libraryPrep-0.0.6",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPrep-0.0.7",
     "description": "The general strategy by which the library was prepared",
+    "type": "string",
     "anyOf": [
         {
             "const": "amplicon",

--- a/terms/ngs/libraryPreparationMethod.json
+++ b/terms/ngs/libraryPreparationMethod.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.libraryPreparationMethod-0.0.4",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryPreparationMethod-0.0.5",
     "description": "Method by which library was prepared",
+    "type": "string",
     "anyOf": [
         {
             "const": "10x",

--- a/terms/ngs/libraryType.json
+++ b/terms/ngs/libraryType.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-ngs.libraryType-0.0.2",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryType-0.0.3",
   "description": "The type of library, in assays where samples are barcoded or hashed for multiplexing or each sample has multiple libraries amplified separately before pooled sequencing.",
+  "type": "string",
   "anyOf": [
     {
       "const": "ADT",

--- a/terms/ngs/libraryVersion.json
+++ b/terms/ngs/libraryVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-ngs.libraryVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.libraryVersion-0.0.2",
     "type": "string",
     "description": "Library Version: for example, rnaSeq 10x library version"
 }

--- a/terms/ngs/nucleicAcidSource.json
+++ b/terms/ngs/nucleicAcidSource.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.nucleicAcidSource-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.nucleicAcidSource-0.0.3",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "bulk cell",

--- a/terms/ngs/readLength.json
+++ b/terms/ngs/readLength.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readLength-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readLength-0.0.2",
     "description": "The length of the read",
     "type": "string"
 }

--- a/terms/ngs/readPair.json
+++ b/terms/ngs/readPair.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readPair-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPair-0.0.2",
     "description": "The read of origin",
+    "type": "string",
     "anyOf": [
         {
             "const": 1,

--- a/terms/ngs/readPairOrientation.json
+++ b/terms/ngs/readPairOrientation.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readPairOrientation-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readPairOrientation-0.0.2",
     "description": "The relative orientation of the reads in a paired-end protocol",
+    "type": "string",
     "anyOf": [
         {
             "const": "inward",

--- a/terms/ngs/readStrandOrigin.json
+++ b/terms/ngs/readStrandOrigin.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.readStrandOrigin-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.readStrandOrigin-0.0.2",
     "description": "The strand from which the read originates in a strand-specific protocol",
+    "type": "string",
     "anyOf": [
         {
             "const": "forward",

--- a/terms/ngs/runType.json
+++ b/terms/ngs/runType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-ngs.runType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.runType-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "singleEnd",

--- a/terms/ngs/sampleBarcode.json
+++ b/terms/ngs/sampleBarcode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "sage.annotations-ngs.sampleBarcode-0.0.1",
+  "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-ngs.sampleBarcode-0.0.2",
   "description": "The nucleotide sequence of the sample barcode used to identify cells from a single sample in cell hashing or multiplexing assays.",
   "type": "string",
   "minLength": 1,

--- a/terms/qc/GQN.json
+++ b/terms/qc/GQN.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.GQN-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.GQN-0.0.2",
     "type": "number",
     "description": "Illumina gDNA quality score"
 }

--- a/terms/qc/RIN.json
+++ b/terms/qc/RIN.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.RIN-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.RIN-0.0.2",
     "type": "number",
     "description": "RNA Integrity Number"
 }

--- a/terms/qc/meanCoverage.json
+++ b/terms/qc/meanCoverage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.meanCoverage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.meanCoverage-0.0.2",
     "type": "number",
     "description": "Total number of bases covered by ATAC-seq reads/size of genome"
 }

--- a/terms/qc/meanGCContent.json
+++ b/terms/qc/meanGCContent.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.meanGCContent-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.meanGCContent-0.0.2",
     "type": "number",
     "description": "Mean GC content per sample"
 }

--- a/terms/qc/medianGenes.json
+++ b/terms/qc/medianGenes.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.medianGenes-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.medianGenes-0.0.2",
     "type": "number",
     "description": "The median number of genes detected (with nonzero UMI counts) across all cell-associated barcodes",
     "source": "https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/gex-metrics"

--- a/terms/qc/medianUMIs.json
+++ b/terms/qc/medianUMIs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.medianUMIs-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.medianUMIs-0.0.2",
     "type": "number",
     "description": "The median number of total Unique Molecular Identifier (UMI) counts across all cell-associated barcodes",
     "source": "https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/gex-metrics"

--- a/terms/qc/organRIN.json
+++ b/terms/qc/organRIN.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.organRIN-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.organRIN-0.0.2",
     "type": "number",
     "description": "A general quality metric of the organ or tissue, not necessarily a direct RIN measure of the sample used in data generation"
 }

--- a/terms/qc/ratio260over230.json
+++ b/terms/qc/ratio260over230.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.ratio260over230-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.ratio260over230-0.0.2",
     "type": "number",
     "description": "Ratio of absorbance at 230 nm and 260 nm. Measures protein or other contaminants. Range up to approximately 2.2."
 }

--- a/terms/qc/ratio260over280.json
+++ b/terms/qc/ratio260over280.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.ratio260over280-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.ratio260over280-0.0.2",
     "type": "number",
     "description": "Measure of DNA vs. RNA purity. Range up to approximately 2.0."
 }

--- a/terms/qc/validBarcodeReads.json
+++ b/terms/qc/validBarcodeReads.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.validBarcodeReads-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.validBarcodeReads-0.0.2",
     "type": "number",
     "description": "Fraction of reads with cell barcodes that match the whitelist",
     "source": "https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/gex-metrics"

--- a/terms/qc/validHiCContacts.json
+++ b/terms/qc/validHiCContacts.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "sage.annotations-qc.validHiCContacts-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-qc.validHiCContacts-0.0.2",
     "type": "number",
     "description": "Percentage of reads as valid Hi-C interactions (QC metric)"
 }

--- a/terms/sageCommunity/consortium.json
+++ b/terms/sageCommunity/consortium.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.consortium-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.consortium-0.0.4",
     "description": "The name of the consortium",
+    "type": "string",
     "anyOf": [
         {
             "const": "CMC",

--- a/terms/sageCommunity/fileFormat.json
+++ b/terms/sageCommunity/fileFormat.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.fileFormat-0.0.3",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fileFormat-0.0.4",
     "description": "Defined format of the data file, typically corresponding to extension, but sometimes indicating more general group of files produced by the same tool or software",
+    "type": "string",
     "anyOf": [
         {
             "const": "Synapse Table",

--- a/terms/sageCommunity/fundingAgency.json
+++ b/terms/sageCommunity/fundingAgency.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.fundingAgency-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.fundingAgency-0.0.2",
     "description": "The organization providing financial support for generation of this data.",
+    "type": "string",
     "anyOf": [
         {
             "const": "CTF",

--- a/terms/sageCommunity/group.json
+++ b/terms/sageCommunity/group.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.group-0.0.2",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.group-0.0.3",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "MSSM",

--- a/terms/sageCommunity/resourceType.json
+++ b/terms/sageCommunity/resourceType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-sageCommunity.resourceType-0.0.4",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-sageCommunity.resourceType-0.0.5",
     "description": "The type of resource being stored and annotated",
+    "type": "string",
     "anyOf": [
         {
             "const": "analysis",

--- a/terms/tool/inputDataType.json
+++ b/terms/tool/inputDataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.inputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.inputDataType-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "genomicVariants",

--- a/terms/tool/outputDataType.json
+++ b/terms/tool/outputDataType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.outputDataType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.outputDataType-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "genomicVariants",

--- a/terms/tool/softwareAuthor.json
+++ b/terms/tool/softwareAuthor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareAuthor-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareAuthor-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareLanguage.json
+++ b/terms/tool/softwareLanguage.json
@@ -1,15 +1,11 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareLanguage-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguage-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
-            "const": "R",
-            "description": "",
-            "source": ""
-        },
-        {
-            "const": "Python",
+            "const": "Java",
             "description": "",
             "source": ""
         },
@@ -19,12 +15,17 @@
             "source": ""
         },
         {
-            "const": "Shell",
+            "const": "Python",
             "description": "",
             "source": ""
         },
         {
-            "const": "Java",
+            "const": "R",
+            "description": "",
+            "source": ""
+        },
+        {
+            "const": "Shell",
             "description": "",
             "source": ""
         }

--- a/terms/tool/softwareLanguageVersion.json
+++ b/terms/tool/softwareLanguageVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareLanguageVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareLanguageVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareName.json
+++ b/terms/tool/softwareName.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareName-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareName-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/tool/softwareRepository.json
+++ b/terms/tool/softwareRepository.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareRepository-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepository-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "Synapse",

--- a/terms/tool/softwareRepositoryType.json
+++ b/terms/tool/softwareRepositoryType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareRepositoryType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareRepositoryType-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "fileStore",

--- a/terms/tool/softwareType.json
+++ b/terms/tool/softwareType.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareType-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareType-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "script",

--- a/terms/tool/softwareVersion.json
+++ b/terms/tool/softwareVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-tool.softwareVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-tool.softwareVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/containerPlatform.json
+++ b/terms/toolExtended/containerPlatform.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatform-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "Docker",

--- a/terms/toolExtended/containerPlatformVersion.json
+++ b/terms/toolExtended/containerPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/containerToolPlatform.json
+++ b/terms/toolExtended/containerToolPlatform.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.containerToolPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.containerToolPlatform-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "Docker-CWL",

--- a/terms/toolExtended/packageBinaryPlatform.json
+++ b/terms/toolExtended/packageBinaryPlatform.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageBinaryPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatform-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "Windows",

--- a/terms/toolExtended/packageBinaryPlatformVersion.json
+++ b/terms/toolExtended/packageBinaryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageBinaryPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/packageLibraryPlatformVersion.json
+++ b/terms/toolExtended/packageLibraryPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.packageLibraryPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }

--- a/terms/toolExtended/workflowPlatform.json
+++ b/terms/toolExtended/workflowPlatform.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.workflowPlatform-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatform-0.0.2",
     "description": "",
+    "type": "string",
     "anyOf": [
         {
             "const": "Nextflow",

--- a/terms/toolExtended/workflowPlatformVersion.json
+++ b/terms/toolExtended/workflowPlatformVersion.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "sage.annotations-toolExtended.workflowPlatformVersion-0.0.1",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-toolExtended.workflowPlatformVersion-0.0.2",
     "description": "",
     "type": "string"
 }


### PR DESCRIPTION
This PR brings in the work from #687, updates it to include absolute paths on newer terms, and adds missing string types for enumerated values.

Includes:
- absolute id paths
- incremented versions
- `"type": "string"` for terms with a list of allowed values
- alphabetical ordering for softwareLanguage
- simple descriptions added for a few terms