### PR TITLE
Do not use absolute path for cellType reference in reprogrammedCellType

### DIFF
--- a/terms/experimentalData/reprogrammedCellType.json
+++ b/terms/experimentalData/reprogrammedCellType.json
@@ -1,10 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.reprogrammedCellType-0.0.5",
+    "$id": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.reprogrammedCellType-0.0.6",
     "description": "Cell type the specimen is modeling",
     "properties": {
         "reprogrammedCellType": {
-            "$ref": "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.annotations-experimentalData.cellType-0.0.8"
+            "$ref": "sage.annotations-experimentalData.cellType-0.0.8"
         }
     }
 }


### PR DESCRIPTION
Absolute paths were added in #851. The absolute paths for ids is fine, but these should not be used for referenced terms.

- Change back to relative path for cellType in reprogrammedCellType