### PR TITLE
Add GH Action to register newly added or modified files on merge and update Synapse table

### DIFF
--- a/.github/workflows/register-schemas-dryrun.yaml
+++ b/.github/workflows/register-schemas-dryrun.yaml
@@ -7,9 +7,7 @@ env:
 
 jobs:
   register-schemas-dryrun:
-    runs-on: macos-10.15
-    strategy:
-      fail-fast: false
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -36,8 +34,7 @@ jobs:
           OUTPUT_FILE=~/.synapseConfig
           cat > "$OUTPUT_FILE" << EOM
           [authentication]
-          username = "${{ secrets.SYNAPSE_USER }}"
-          apikey = "${{ secrets.SYNAPSE_APIKEY}}"
+          authtoken = "${{ secrets.SYNAPSE_PAT }}"
           EOM
           chmod +x "$OUTPUT_FILE"
 

--- a/.github/workflows/register-schemas-dryrun.yaml
+++ b/.github/workflows/register-schemas-dryrun.yaml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   register-schemas-dryrun:
-    runs-on: ubuntu-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/register-schemas.yaml
+++ b/.github/workflows/register-schemas.yaml
@@ -9,9 +9,7 @@ env:
 
 jobs:
   register-schemas-dryrun:
-    runs-on: macos-10.15
-    strategy:
-      fail-fast: false
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -38,8 +36,7 @@ jobs:
           OUTPUT_FILE=~/.synapseConfig
           cat > "$OUTPUT_FILE" << EOM
           [authentication]
-          username = "${{ secrets.SYNAPSE_USER }}"
-          apikey = "${{ secrets.SYNAPSE_APIKEY}}"
+          authtoken = "${{ secrets.SYNAPSE_PAT }}"
           EOM
           chmod +x "$OUTPUT_FILE"
 

--- a/.github/workflows/register-schemas.yaml
+++ b/.github/workflows/register-schemas.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches: master
 
-name: Register schemas
+name: Register schemas & update table
 
 env:
   RENV_PATHS_ROOT: ~/.local/share/renv
@@ -49,7 +49,11 @@ jobs:
         with:
           output: ','
 
-      - name: Attempt to register schemas in Synapse
+      - name: Register schemas in Synapse
         run: |
           files="${{ steps.get_file_changes.outputs.files_added }},${{ steps.get_file_changes.outputs.files_modified }}"
           echo $files | tr ',' '\n' | grep -Z '^terms.*\.json$' | xargs ./register-schemas.R
+
+      - name: Update Synapse table
+        run: |
+          ./update-annotations-table.R

--- a/.github/workflows/register-schemas.yaml
+++ b/.github/workflows/register-schemas.yaml
@@ -1,0 +1,55 @@
+on:
+  push:
+    branches: master
+
+name: Register schemas
+
+env:
+  RENV_PATHS_ROOT: ~/.local/share/renv
+
+jobs:
+  register-schemas-dryrun:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: '4.0'
+
+      - name: Cache packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.RENV_PATHS_ROOT }}
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
+
+      - name: Restore packages
+        shell: Rscript {0}
+        run: |
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::restore()
+
+      - name: Set up Synapse config file for testing
+        run: |
+          OUTPUT_FILE=~/.synapseConfig
+          cat > "$OUTPUT_FILE" << EOM
+          [authentication]
+          username = "${{ secrets.SYNAPSE_USER }}"
+          apikey = "${{ secrets.SYNAPSE_APIKEY}}"
+          EOM
+          chmod +x "$OUTPUT_FILE"
+
+      - name: Get file changes
+        id: get_file_changes
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          output: ','
+
+      - name: Attempt to register schemas in Synapse
+        run: |
+          files="${{ steps.get_file_changes.outputs.files_added }},${{ steps.get_file_changes.outputs.files_modified }}"
+          echo $files | tr ',' '\n' | grep -Z '^terms.*\.json$' | xargs ./register-schemas.R

--- a/.github/workflows/register-schemas.yaml
+++ b/.github/workflows/register-schemas.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches: master
 
-name: Register schemas & update table
+name: Register schemas & update tables
 
 env:
   RENV_PATHS_ROOT: ~/.local/share/renv
@@ -51,6 +51,10 @@ jobs:
           files="${{ steps.get_file_changes.outputs.files_added }},${{ steps.get_file_changes.outputs.files_modified }}"
           echo $files | tr ',' '\n' | grep -Z '^terms.*\.json$' | xargs ./register-schemas.R
 
-      - name: Update Synapse table
+      - name: Update Synapse key-value table
         run: |
           ./update-annotations-table.R
+
+      - name: Update Synapse schema versions table
+        run: |
+          ./update-schema-version-table.R

--- a/.github/workflows/register-schemas.yaml
+++ b/.github/workflows/register-schemas.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   register-schemas-dryrun:
-    runs-on: ubuntu-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
 

--- a/update-schema-version-table.R
+++ b/update-schema-version-table.R
@@ -1,0 +1,92 @@
+#!/usr/bin/Rscript
+###############################################################
+####  Update the Synapse Annotations Schema Version table  ####
+###############################################################
+
+library("jsonlite")
+library("tidyverse")
+library("reticulate")
+library("glue")
+library("here")
+
+## Helper functions ------------------------------------------------------------
+
+#' Extract module or annotation key name from $id field
+#'
+#' @param id string containing the schema `$id`
+#' @param info one of "id" (organization-module.key), "module", "key",
+#' or "version"
+#' @param absolute_path string containing the absolute path prefix to remove
+#' @return The id, module, key, or version
+get_info <- function(id, info = c("id", "module", "key", "version"),
+                     absolute_path = "https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/") {
+  ## Remove absolute path for simpler regex; we know the format for Sage schemas
+  id <- gsub(absolute_path, "", id)
+  info <- match.arg(info)
+  pattern <- "^[^-]+-([[:alnum:]]+)\\.([[:alnum:]]+)-([0-9\\.]+)"
+  switch(
+    info,
+    id = gsub("-[0-9\\.]+$", "", id),
+    module = gsub(pattern, "\\1", id),
+    key = gsub(pattern, "\\2", id),
+    version = gsub(pattern, "\\3", id)
+  )
+}
+
+#' Extract file path from referenced id
+#'
+#' @param id string containing the schema `$id`
+#' @return The local file path to the schema for the `$id`
+get_ref_path <- function(id) {
+  module <- get_info(id, "module")
+  key <- get_info(id, "key")
+  glue::glue("{here('terms')}/{module}/{key}.json")
+}
+
+#' Create table row for tracking schema versions
+#'
+#' @param file Path to the JSON Schema file.
+#' @return
+create_rows_schema <- function(file) {
+  dat <- fromJSON(file)
+  ## Grab information from the full id
+  tibble::tibble(
+    key = get_info(dat$`$id`, "key"),
+    latestVersion = get_info(dat$`$id`, "version"),
+    schema = get_info(dat$`$id`, "id"),
+    module = get_info(dat$`$id`, "module")
+  )
+}
+
+## -----------------------------------------------------------------------------
+
+## Log in to synapse
+synapse <- import("synapseclient")
+syn <- synapse$Synapse()
+syn$login()
+
+## JSON files
+files <- list.files(
+  here("terms"),
+  # here("terms"),
+  pattern = "\\.json$",
+  full.names = TRUE,
+  recursive = TRUE
+)
+
+## Update schema version table
+dat_schema <- map_dfr(files, create_rows_schema)
+
+## Delete old table rows
+schema_table <- "syn26050066"
+current_schema <- syn$tableQuery(glue("SELECT * FROM {schema_table}"))
+syn$delete(current_schema) # delete current rows
+
+## Update table rows
+temp_schema <- tempfile()
+write_csv(dat_schema, temp_schema, na = "")
+new_schema <- synapse$Table(schema_table, temp_schema)
+syn$store(new_schema)
+
+## Query to force table index to rebuild
+syn$tableQuery(glue("SELECT ROW_ID FROM {schema_table}"))


### PR DESCRIPTION
A GH Action exists to test that newly added/modified files can be registered in Synapse, but the terms are not actually registered. This is a second action that would register the terms in Synapse once they are merged into the main branch. The code here is an updated version of the dryrun action.

GH Actions are tough to test before deploying, especially when they trigger on the main branch. If someone could skim this and gives a thumbs up if it looks okay, that would be great!

Edit: I also decided to throw in the table update since that should be done on merge to main, as well.