### PR TITLE
Update synapser in renv.lock & use in table scripts

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.3",
+    "Version": "3.6.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -43,10 +43,10 @@
     },
     "PythonEmbedInR": {
       "Package": "PythonEmbedInR",
-      "Version": "0.6.76",
+      "Version": "0.8.4",
       "Source": "Repository",
       "Repository": null,
-      "Hash": "193b9cbc3c24053c945d453e86912e07"
+      "Hash": "9a489905fb7363c0c2980453131586c6"
     },
     "R6": {
       "Package": "R6",
@@ -496,13 +496,6 @@
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
     },
-    "rappdirs": {
-      "Package": "rappdirs",
-      "Version": "0.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8c8298583adbbe76f3c2220eef71bebc"
-    },
     "readr": {
       "Package": "readr",
       "Version": "1.4.0",
@@ -542,13 +535,6 @@
       "RemoteRef": "HEAD",
       "RemoteSha": "d3fc4b8bedeb9622b9941faa073ee65b3ebd7dbb",
       "Hash": "f82a60f2042a9493f6c9315dca2261fc"
-    },
-    "reticulate": {
-      "Package": "reticulate",
-      "Version": "1.18",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "fbd35cac6ae7554d0e4f440bca1adf3a"
     },
     "rjson": {
       "Package": "rjson",
@@ -622,10 +608,10 @@
     },
     "synapser": {
       "Package": "synapser",
-      "Version": "0.9.77",
+      "Version": "0.11.7",
       "Source": "Repository",
       "Repository": null,
-      "Hash": "431f1fa3e6c1327c849858c451175836"
+      "Hash": "799a9fb65ed0003716e629c97e9c152c"
     },
     "sys": {
       "Package": "sys",

--- a/update-annotations-table.R
+++ b/update-annotations-table.R
@@ -5,7 +5,7 @@
 
 library("jsonlite")
 library("tidyverse")
-library("reticulate")
+library("synapser")
 library("glue")
 library("httr")
 library("here")
@@ -135,9 +135,7 @@ create_rows_schema <- function(file) {
 }
 
 ## Log in to synapse
-synapse <- import("synapseclient")
-syn <- synapse$Synapse()
-syn$login()
+synLogin()
 
 ## JSON files
 files <- list.files(
@@ -152,31 +150,14 @@ dat_dict <- map_dfr(files, create_rows_dict)
 
 ## Delete old table rows
 annots_table <- "syn10242922"
-current <- syn$tableQuery(glue("SELECT * FROM {annots_table}"))
-syn$delete(current) # delete current rows
+current <- synTableQuery(glue("SELECT * FROM {annots_table}"))
+synDelete(current) # delete current rows
 
 ## Update table rows
 temp <- tempfile()
 write_csv(dat_dict, temp, na = "")
-new <- synapse$Table(annots_table, temp)
-syn$store(new)
+new <- Table(annots_table, temp)
+synStore(new)
 
 ## Query to force table index to rebuild
-syn$tableQuery(glue("SELECT ROW_ID FROM {annots_table}"))
-
-## Schema version table
-dat_schema <- map_dfr(files, create_rows_schema)
-
-## Delete old table rows
-schema_table <- "syn26050066"
-current_schema <- syn$tableQuery(glue("SELECT * FROM {schema_table}"))
-syn$delete(current_schema) # delete current rows
-
-## Update table rows
-temp_schema <- tempfile()
-write_csv(dat_schema, temp_schema, na = "")
-new_schema <- synapse$Table(schema_table, temp_schema)
-syn$store(new_schema)
-
-## Query to force table index to rebuild
-syn$tableQuery(glue("SELECT ROW_ID FROM {schema_table}"))
+synTableQuery(glue("SELECT ROW_ID FROM {annots_table}"))

--- a/update-schema-version-table.R
+++ b/update-schema-version-table.R
@@ -5,7 +5,7 @@
 
 library("jsonlite")
 library("tidyverse")
-library("reticulate")
+library("synapser")
 library("glue")
 library("here")
 
@@ -61,9 +61,7 @@ create_rows_schema <- function(file) {
 ## -----------------------------------------------------------------------------
 
 ## Log in to synapse
-synapse <- import("synapseclient")
-syn <- synapse$Synapse()
-syn$login()
+synLogin()
 
 ## JSON files
 files <- list.files(
@@ -79,14 +77,14 @@ dat_schema <- map_dfr(files, create_rows_schema)
 
 ## Delete old table rows
 schema_table <- "syn26050066"
-current_schema <- syn$tableQuery(glue("SELECT * FROM {schema_table}"))
-syn$delete(current_schema) # delete current rows
+current_schema <- synTableQuery(glue("SELECT * FROM {schema_table}"))
+synDelete(current_schema) # delete current rows
 
 ## Update table rows
 temp_schema <- tempfile()
 write_csv(dat_schema, temp_schema, na = "")
-new_schema <- synapse$Table(schema_table, temp_schema)
-syn$store(new_schema)
+new_schema <- Table(schema_table, temp_schema)
+synStore(new_schema)
 
 ## Query to force table index to rebuild
-syn$tableQuery(glue("SELECT ROW_ID FROM {schema_table}"))
+synTableQuery(glue("SELECT ROW_ID FROM {schema_table}"))


### PR DESCRIPTION
Forgot that I had switched to reticulate + python client for the cron and didn't update the scripts to use synapser, again. Updated scripts and renv.lock to have latest synapser version.