### PR TITLE
Add alias to schema version table and Synapse PAT to GH Action

### DIFF
--- a/.github/workflows/register-schemas-dryrun.yaml
+++ b/.github/workflows/register-schemas-dryrun.yaml
@@ -4,6 +4,7 @@ name: Register schemas (dry run)
 
 env:
   RENV_PATHS_ROOT: ~/.local/share/renv
+  SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_PAT }}
 
 jobs:
   register-schemas-dryrun:

--- a/update-schema-version-table.R
+++ b/update-schema-version-table.R
@@ -54,7 +54,8 @@ create_rows_schema <- function(file) {
     key = get_info(dat$`$id`, "key"),
     latestVersion = get_info(dat$`$id`, "version"),
     schema = get_info(dat$`$id`, "id"),
-    module = get_info(dat$`$id`, "module")
+    module = get_info(dat$`$id`, "module"),
+    alias = glue("{get_info(dat$`$id`, 'module')}_{get_info(dat$`$id`, 'key')}")
   )
 }
 


### PR DESCRIPTION
Updates the schema version table to have an alias for each term in the format "module_key". This can then be used as an anchor in yaml files. Also adds the Synapse PAT to the dryrun GH Action that happens on PR.